### PR TITLE
proxy: fix the handle to drop table

### DIFF
--- a/src/proxy/ddl.go
+++ b/src/proxy/ddl.go
@@ -170,7 +170,9 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node sq
 		r, err := spanner.ExecuteDDL(session, database, query, node)
 		if err != nil {
 			log.Error("spanner.ddl.execute[%v].error[%+v]", query, err)
+			return nil, err
 		}
+
 		if err := router.DropTable(database, table); err != nil {
 			log.Error("spanner.ddl.router.drop.table[%s].error[%+v]", table, err)
 		}


### PR DESCRIPTION
issue case1:
        the ExecuteDDL of DROPTABLE is failed, the router.DropTable is successful:
        1. the err is nil;
        2. the ExecuteDDL is failed, but table in the metafile is deleted