### PR TITLE
proxy: fix the unsupport subquery report err #154

### DIFF
--- a/src/proxy/query.go
+++ b/src/proxy/query.go
@@ -218,13 +218,13 @@ func (spanner *Spanner) ComQuery(session *driver.Session, query string, callback
 			switch snode.From[0].(type) {
 			case *sqlparser.AliasedTableExpr:
 				aliasTableExpr := snode.From[0].(*sqlparser.AliasedTableExpr)
-				tb := aliasTableExpr.Expr.(sqlparser.TableName)
-				table := tb.Name.String()
-				if table == "dual" {
+				tb, ok := aliasTableExpr.Expr.(sqlparser.TableName)
+				if ok && tb.Name.String() == "dual" {
 					if qr, err = spanner.handleDual(session, query, node); err != nil {
 						log.Error("proxy.select[%s].from.session[%v].error:%+v", query, session.ID(), err)
 					}
-				} else { // e.g.: select a from table [as] aliasTable;
+				} else {
+					// e.g.: select a from table [as] aliasTable;
 					if qr, err = spanner.handleSelect(session, query, node); err != nil {
 						log.Error("proxy.select[%s].from.session[%v].error:%+v", query, session.ID(), err)
 					}

--- a/src/proxy/query_test.go
+++ b/src/proxy/query_test.go
@@ -221,6 +221,17 @@ func TestProxyQueryStream(t *testing.T) {
 		}
 	}
 
+	//select from `subquery` error
+	{
+		client, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.Nil(t, err)
+		query := "select id from (select * from test.t1) as aliaseTable"
+		_, err = client.FetchAll(query, -1)
+		assert.NotNil(t, err)
+		want := "unsupported: subqueries.in.select (errno 1105) (sqlstate HY000)"
+		got := err.Error()
+		assert.Equal(t, want, got)
+	}
 	// select .* from dual  error
 	{
 		client, err := driver.NewConn("mock", "mock", address, "", "utf8")


### PR DESCRIPTION
```
mysql> select * from (select * from tb1) as tb;
ERROR 1105 (HY000): unsupported: subqueries.in.select
```