### PR TITLE
proxy: change ExecuteTwoPC to be original just handling the single

### DIFF
--- a/src/proxy/delete.go
+++ b/src/proxy/delete.go
@@ -17,5 +17,5 @@ import (
 // handleDelete used to handle the delete command.
 func (spanner *Spanner) handleDelete(session *driver.Session, query string, node sqlparser.Statement) (*sqltypes.Result, error) {
 	database := session.Schema()
-	return spanner.Execute(session, database, query, node)
+	return spanner.ExecuteDML(session, database, query, node)
 }

--- a/src/proxy/insert.go
+++ b/src/proxy/insert.go
@@ -17,5 +17,5 @@ import (
 // handleInsert used to handle the insert command.
 func (spanner *Spanner) handleInsert(session *driver.Session, query string, node sqlparser.Statement) (*sqltypes.Result, error) {
 	database := session.Schema()
-	return spanner.Execute(session, database, query, node)
+	return spanner.ExecuteDML(session, database, query, node)
 }

--- a/src/proxy/select.go
+++ b/src/proxy/select.go
@@ -17,7 +17,7 @@ import (
 // handleSelect used to handle the select command.
 func (spanner *Spanner) handleSelect(session *driver.Session, query string, node sqlparser.Statement) (*sqltypes.Result, error) {
 	database := session.Schema()
-	return spanner.Execute(session, database, query, node)
+	return spanner.ExecuteDML(session, database, query, node)
 }
 
 func (spanner *Spanner) handleSelectStream(session *driver.Session, query string, node sqlparser.Statement, callback func(qr *sqltypes.Result) error) error {

--- a/src/proxy/update.go
+++ b/src/proxy/update.go
@@ -17,5 +17,5 @@ import (
 // handleUpdate used to handle the update command.
 func (spanner *Spanner) handleUpdate(session *driver.Session, query string, node sqlparser.Statement) (*sqltypes.Result, error) {
 	database := session.Schema()
-	return spanner.Execute(session, database, query, node)
+	return spanner.ExecuteDML(session, database, query, node)
 }


### PR DESCRIPTION
statement, rename some functions to clear covered scope #77

the last change about ExecuteTwoPC is:
https://github.com/radondb/radon/commit/4b6377edd8c4dd87e991a1b0b5a82686d96617e4