### PR TITLE
*: fix avg push as sum&count instand of avg&sum&count #211

### DIFF
--- a/src/executor/aggregate_executor.go
+++ b/src/executor/aggregate_executor.go
@@ -78,9 +78,9 @@ func (executor *AggregateExecutor) aggregate(result *sqltypes.Result) {
 		for _, aggr := range aggrs {
 			switch aggr.Type {
 			case planner.AggrTypeAvg:
-				v1, v2 := v[aggr.Index+1], v[aggr.Index+2]
+				v1, v2 := v[aggr.Index], v[aggr.Index+1]
 				v[aggr.Index] = sqltypes.Operator(v1, v2, sqltypes.DivFn)
-				deIdxs = append(deIdxs, aggr.Index+1, aggr.Index+2)
+				deIdxs = append(deIdxs, aggr.Index+1)
 			}
 		}
 		result.Rows[i] = v

--- a/src/executor/aggregate_executor_test.go
+++ b/src/executor/aggregate_executor_test.go
@@ -145,17 +145,12 @@ func TestAggregateAvgExecutor(t *testing.T) {
 				Type: querypb.Type_FLOAT32,
 			},
 			{
-				Name: "sum(score)",
-				Type: querypb.Type_INT32,
-			},
-			{
 				Name: "count(score)",
 				Type: querypb.Type_INT32,
 			},
 		},
 		Rows: [][]sqltypes.Value{
 			{
-				sqltypes.MakeTrusted(querypb.Type_FLOAT32, []byte("0")),
 				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("3")),
 				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("1")),
 			},
@@ -169,17 +164,12 @@ func TestAggregateAvgExecutor(t *testing.T) {
 				Type: querypb.Type_FLOAT32,
 			},
 			{
-				Name: "sum(score)",
-				Type: querypb.Type_INT32,
-			},
-			{
 				Name: "count(score)",
 				Type: querypb.Type_INT32,
 			},
 		},
 		Rows: [][]sqltypes.Value{
 			{
-				sqltypes.MakeTrusted(querypb.Type_FLOAT32, []byte("0")),
 				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("13")),
 				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("3")),
 			},
@@ -199,10 +189,10 @@ func TestAggregateAvgExecutor(t *testing.T) {
 	scatter, fakedbs, cleanup := backend.MockScatter(log, 10)
 	defer cleanup()
 	// avg.
-	fakedbs.AddQuery("select avg(score) as score, sum(score), count(score) from sbtest.A0 as A where id > 8", r1)
-	fakedbs.AddQuery("select avg(score) as score, sum(score), count(score) from sbtest.A2 as A where id > 8", r1)
-	fakedbs.AddQuery("select avg(score) as score, sum(score), count(score) from sbtest.A4 as A where id > 8", r1)
-	fakedbs.AddQuery("select avg(score) as score, sum(score), count(score) from sbtest.A8 as A where id > 8", r2)
+	fakedbs.AddQuery("select sum(score) as score, count(score) from sbtest.A0 as A where id > 8", r1)
+	fakedbs.AddQuery("select sum(score) as score, count(score) from sbtest.A2 as A where id > 8", r1)
+	fakedbs.AddQuery("select sum(score) as score, count(score) from sbtest.A4 as A where id > 8", r1)
+	fakedbs.AddQuery("select sum(score) as score, count(score) from sbtest.A8 as A where id > 8", r2)
 
 	querys := []string{
 		"select avg(score) as score from A where id>8",

--- a/src/planner/aggregate_plan.go
+++ b/src/planner/aggregate_plan.go
@@ -135,15 +135,15 @@ func (p *AggregatePlan) analyze() error {
 			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: tuple.field, Index: k, Type: AggrTypeMax})
 		case "avg":
 			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: tuple.field, Index: k, Type: AggrTypeAvg})
-			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: fmt.Sprintf("sum(%s)", tuple.column), Index: k + 1, Type: AggrTypeSum})
-			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: fmt.Sprintf("count(%s)", tuple.column), Index: k + 2, Type: AggrTypeCount})
+			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: fmt.Sprintf("sum(%s)", tuple.column), Index: k, Type: AggrTypeSum})
+			p.normalAggrs = append(p.normalAggrs, Aggregator{Field: fmt.Sprintf("count(%s)", tuple.column), Index: k + 1, Type: AggrTypeCount})
 
 			avgs := decomposeAvg(&tuple)
-			p.rewritten = append(p.rewritten, &sqlparser.AliasedExpr{}, &sqlparser.AliasedExpr{})
-			copy(p.rewritten[(k+1)+2:], p.rewritten[(k+1):])
-			p.rewritten[(k + 1)] = avgs[0]
-			p.rewritten[(k+1)+1] = avgs[1]
-			k += 2
+			p.rewritten = append(p.rewritten, &sqlparser.AliasedExpr{})
+			copy(p.rewritten[(k+2):], p.rewritten[k+1:])
+			p.rewritten[k] = avgs[0]
+			p.rewritten[(k + 1)] = avgs[1]
+			k++
 		default:
 			return errors.Errorf("unsupported: function:%+v", tuple.fn)
 		}

--- a/src/planner/aggregate_plan_test.go
+++ b/src/planner/aggregate_plan_test.go
@@ -40,52 +40,52 @@ func TestAggregatePlan(t *testing.T) {
 		},
 		{
 			"Field": "sum(a)",
-			"Index": 5,
+			"Index": 4,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(a)",
-			"Index": 6,
+			"Index": 5,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "sum(a)",
-			"Index": 7,
+			"Index": 6,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(a)",
-			"Index": 8,
+			"Index": 7,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "avg(b)",
-			"Index": 10,
+			"Index": 9,
 			"Type": "AVG"
 		},
 		{
 			"Field": "sum(b)",
-			"Index": 11,
+			"Index": 9,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(b)",
-			"Index": 12,
+			"Index": 10,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "avg(c)",
-			"Index": 14,
+			"Index": 12,
 			"Type": "AVG"
 		},
 		{
 			"Field": "sum(c)",
-			"Index": 15,
+			"Index": 12,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(c)",
-			"Index": 16,
+			"Index": 13,
 			"Type": "COUNT"
 		},
 		{
@@ -95,16 +95,16 @@ func TestAggregatePlan(t *testing.T) {
 		},
 		{
 			"Field": "b1",
-			"Index": 9,
+			"Index": 8,
 			"Type": "GROUP BY"
 		},
 		{
 			"Field": "c",
-			"Index": 13,
+			"Index": 11,
 			"Type": "GROUP BY"
 		}
 	],
-	"ReWritten": "1, a, min(b), max(a), avg(a), sum(a), count(a), sum(a), count(a), b as b1, avg(b), sum(b), count(b), c, avg(c), sum(c), count(c)"
+	"ReWritten": "1, a, min(b), max(a), sum(a) as ` + "`avg(a)`" + `, count(a), sum(a), count(a), b as b1, sum(b) as ` + "`avg(b)`" + `, count(b), c, sum(c) as ` + "`avg(c)`" + `, count(c)"
 }`,
 	}
 
@@ -158,52 +158,52 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 		},
 		{
 			"Field": "sum(a)",
-			"Index": 5,
+			"Index": 4,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(a)",
-			"Index": 6,
+			"Index": 5,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "SUM(a)",
-			"Index": 7,
+			"Index": 6,
 			"Type": "SUM"
 		},
 		{
 			"Field": "COUNT(a)",
-			"Index": 8,
+			"Index": 7,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "AVG(b)",
-			"Index": 10,
+			"Index": 9,
 			"Type": "AVG"
 		},
 		{
 			"Field": "sum(b)",
-			"Index": 11,
+			"Index": 9,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(b)",
-			"Index": 12,
+			"Index": 10,
 			"Type": "COUNT"
 		},
 		{
 			"Field": "AVG(c)",
-			"Index": 14,
+			"Index": 12,
 			"Type": "AVG"
 		},
 		{
 			"Field": "sum(c)",
-			"Index": 15,
+			"Index": 12,
 			"Type": "SUM"
 		},
 		{
 			"Field": "count(c)",
-			"Index": 16,
+			"Index": 13,
 			"Type": "COUNT"
 		},
 		{
@@ -213,16 +213,16 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 		},
 		{
 			"Field": "b1",
-			"Index": 9,
+			"Index": 8,
 			"Type": "GROUP BY"
 		},
 		{
 			"Field": "c",
-			"Index": 13,
+			"Index": 11,
 			"Type": "GROUP BY"
 		}
 	],
-	"ReWritten": "1, a, MIN(b), MAX(a), AVG(a), sum(a), count(a), SUM(a), COUNT(a), b as b1, AVG(b), sum(b), count(b), c, AVG(c), sum(c), count(c)"
+	"ReWritten": "1, a, MIN(b), MAX(a), sum(a) as ` + "`AVG(a)`" + `, count(a), SUM(a), COUNT(a), b as b1, sum(b) as ` + "`AVG(b)`" + `, count(b), c, sum(c) as ` + "`AVG(c)`" + `, count(c)"
 }`,
 	}
 

--- a/src/planner/expr.go
+++ b/src/planner/expr.go
@@ -204,10 +204,13 @@ func checkInTuple(name string, tuples []selectTuple) bool {
 // decomposeAvg decomposes avg(a) to sum(a) and count(a).
 func decomposeAvg(tuple *selectTuple) []*sqlparser.AliasedExpr {
 	var ret []*sqlparser.AliasedExpr
-	sum := &sqlparser.AliasedExpr{Expr: &sqlparser.FuncExpr{
-		Name:  sqlparser.NewColIdent("sum"),
-		Exprs: []sqlparser.SelectExpr{&sqlparser.AliasedExpr{Expr: sqlparser.NewValArg([]byte(tuple.column))}},
-	}}
+	sum := &sqlparser.AliasedExpr{
+		Expr: &sqlparser.FuncExpr{
+			Name:  sqlparser.NewColIdent("sum"),
+			Exprs: []sqlparser.SelectExpr{&sqlparser.AliasedExpr{Expr: sqlparser.NewValArg([]byte(tuple.column))}},
+		},
+		As: sqlparser.NewColIdent(tuple.field),
+	}
 	count := &sqlparser.AliasedExpr{Expr: &sqlparser.FuncExpr{
 		Name:  sqlparser.NewColIdent("count"),
 		Exprs: []sqlparser.SelectExpr{&sqlparser.AliasedExpr{Expr: sqlparser.NewValArg([]byte(tuple.column))}},

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -22,35 +22,35 @@ func TestSelectPlan(t *testing.T) {
 	results := []string{
 		`{
 	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.A where id\u003e1 group by a,b order by a desc limit 10 offset 100",
-	"Project": "1, sum(a), avg(a), sum(a), count(a), a, b",
+	"Project": "1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A1 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A1 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[0-32)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A2 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A2 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[32-64)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A3 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A3 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[64-96)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A4 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A4 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[96-256)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A5 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A5 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend5",
 			"Range": "[256-512)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A6 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A6 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}
@@ -155,35 +155,35 @@ func TestSelectPlanDatabaseIsNull(t *testing.T) {
 	results := []string{
 		`{
 	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.A where id\u003e1 group by a,b order by a desc limit 10 offset 100",
-	"Project": "1, sum(a), avg(a), sum(a), count(a), a, b",
+	"Project": "1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A1 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A1 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[0-32)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A2 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A2 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[32-64)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A3 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A3 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[64-96)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A4 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A4 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[96-256)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A5 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A5 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend5",
 			"Range": "[256-512)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from sbtest.A6 as A where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A6 as A where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}

--- a/src/proxy/explain_test.go
+++ b/src/proxy/explain_test.go
@@ -48,155 +48,155 @@ func TestProxyExplain(t *testing.T) {
 		assert.Nil(t, err)
 		want := `{
 	"RawQuery": " select 1, sum(a),avg(a),a,b from test.t1 as t1 where id\u003e1 group by a,b order by a desc limit 10 offset 100",
-	"Project": "1, sum(a), avg(a), sum(a), count(a), a, b",
+	"Project": "1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0000 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0000 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[0-128)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0001 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0001 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[128-256)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0002 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0002 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[256-384)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0003 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0003 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[384-512)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0004 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0004 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[512-640)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0005 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0005 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend0",
 			"Range": "[640-819)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0006 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0006 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[819-947)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0007 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0007 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[947-1075)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0008 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0008 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[1075-1203)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0009 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0009 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[1203-1331)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0010 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0010 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[1331-1459)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0011 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0011 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend1",
 			"Range": "[1459-1638)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0012 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0012 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[1638-1766)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0013 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0013 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[1766-1894)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0014 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0014 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[1894-2022)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0015 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0015 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[2022-2150)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0016 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0016 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[2150-2278)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0017 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0017 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend2",
 			"Range": "[2278-2457)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0018 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0018 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[2457-2585)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0019 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0019 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[2585-2713)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0020 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0020 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[2713-2841)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0021 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0021 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[2841-2969)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0022 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0022 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[2969-3097)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0023 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0023 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend3",
 			"Range": "[3097-3276)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0024 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0024 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3276-3404)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0025 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0025 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3404-3532)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0026 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0026 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3532-3660)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0027 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0027 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3660-3788)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0028 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0028 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3788-3916)"
 		},
 		{
-			"Query": "select 1, sum(a), avg(a), sum(a), count(a), a, b from test.t1_0029 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0029 as t1 where id \u003e 1 group by a, b order by a desc limit 110",
 			"Backend": "backend4",
 			"Range": "[3916-4096)"
 		}


### PR DESCRIPTION
After modification, the results are as follows：
```
mysql>  explain select avg(a),min(a),count(a),sum(a) from tb2;
+---------------------------------------------------------------+
| EXPLAIN  |
+---------------------------------------------------------------+
| {
        "RawQuery": " select avg(a),min(a),count(a),sum(a) from tb2",
        "Project": "sum(a) as `avg(a)`, count(a), min(a), count(a), sum(a)",
        "Partitions": [
                {
                        "Query": "select sum(a) as `avg(a)`, count(a), min(a), count(a),
                                        sum(a) from tests.tb2_0000 as tb2",
                        "Backend": "backend1",
                        "Range": "[0-64)"
                },
                .... ....
                {
                        "Query": "select sum(a) as `avg(a)`, count(a), min(a), count(a),
                                        sum(a) from tests.tb2_0063 as tb2",
                        "Backend": "backend3",
                        "Range": "[4032-4096)"
                }
        ],
        "Aggregate": [
                "avg(a)",
                "sum(a)",
                "count(a)",
                "min(a)",
                "count(a)",
                "sum(a)"
        ]
} |
+---------------------------------------+
1 row in set (0.00 sec)

mysql> select avg(a),min(a),count(a),sum(a) from tb2;        
+--------+--------+----------+--------+
| avg(a) | min(a) | count(a) | sum(a) |
+--------+--------+----------+--------+
| 19.875 |      1 |        8 |    159 |
+--------+--------+----------+--------+
1 row in set (0.01 sec)
```
```
mysql>  explain select avg(a) as a,min(a),count(a),sum(a) from tb2;
+---------------------------------------------------------------+
| EXPLAIN  |
+---------------------------------------------------------------+
| {
        "RawQuery": " select avg(a) as a,min(a),count(a),sum(a) from tb2",
        "Project": "sum(a) as a, count(a), min(a), count(a), sum(a)",
        "Partitions": [
                {
                        "Query": "select sum(a) as a, count(a), min(a), count(a), 
                                        sum(a) from tests.tb2_0000 as tb2",
                        "Backend": "backend1",
                        "Range": "[0-64)"
                },
                .... ....
                {
                        "Query": "select sum(a) as a, count(a), min(a), count(a), 
                                       sum(a) from tests.tb2_0063 as tb2",
                        "Backend": "backend3",
                        "Range": "[4032-4096)"
                }
        ],
        "Aggregate": [
                "a",
                "sum(a)",
                "count(a)",
                "min(a)",
                "count(a)",
                "sum(a)"
        ]
} |
+---------------------------------------+
1 row in set (0.00 sec)

mysql> select avg(a) as a,min(a),count(a),sum(a) from tb2;        
+--------+--------+----------+--------+
| a      | min(a) | count(a) | sum(a) |
+--------+--------+----------+--------+
| 19.875 |      1 |        8 |    159 |
+--------+--------+----------+--------+
1 row in set (0.01 sec)
```