### PR TITLE
planner: group by contain shard key optimization

### DIFF
--- a/src/planner/aggregate_plan_test.go
+++ b/src/planner/aggregate_plan_test.go
@@ -124,7 +124,8 @@ func TestAggregatePlan(t *testing.T) {
 		tuples, hasAgg, err := parserSelectExprs(node.SelectExprs, p)
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -251,7 +252,8 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 		tuples, hasAgg, err := parserSelectExprs(node.SelectExprs, p)
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -307,7 +309,8 @@ func TestAggregatePlanHaving(t *testing.T) {
 		tuples, hasAgg, err := parserSelectExprs(node.SelectExprs, p)
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -352,7 +355,8 @@ func TestAggregatePlanUnsupported(t *testing.T) {
 		tuples, hasAgg, err := parserSelectExprs(node.SelectExprs, p)
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
 		if err == nil {
 			plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 			err := plan.Build()
@@ -422,7 +426,8 @@ func TestAggregatePlans(t *testing.T) {
 		tuples, hasAgg, err := parserSelectExprs(node.SelectExprs, p)
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build

--- a/src/planner/expr_test.go
+++ b/src/planner/expr_test.go
@@ -217,10 +217,11 @@ func TestCheckGroupBy(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		assert.Equal(t, wants[i], len(groups))
 	}
@@ -255,10 +256,11 @@ func TestCheckGroupByError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
-		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
 		got := err.Error()
 		assert.Equal(t, wants[i], got)
 	}
@@ -293,10 +295,10 @@ func TestCheckDistinct(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
-
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 		assert.Equal(t, wants[i], len(sel.GroupBy))
 	}
@@ -329,10 +331,10 @@ func TestCheckDistinctError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
-
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), !hasAgg && ok)
 		got := err.Error()
 		assert.Equal(t, wants[i], got)
 	}
@@ -362,10 +364,11 @@ func TestSelectExprs(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, false)
@@ -404,10 +407,11 @@ func TestSelectExprsError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, false)
@@ -424,10 +428,11 @@ func TestSelectExprsError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables())
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, true)

--- a/src/planner/select_plan.go
+++ b/src/planner/select_plan.go
@@ -124,11 +124,11 @@ func (p *SelectPlan) Build() error {
 		return err
 	}
 
-	if groups, err = checkGroupBy(node.GroupBy, fields, p.router, tbInfos); err != nil {
+	if groups, err = checkGroupBy(node.GroupBy, fields, p.router, tbInfos, !hasAggregates && ok); err != nil {
 		return err
 	}
 
-	if groups, err = checkDistinct(node, groups, fields, p.router, tbInfos); err != nil {
+	if groups, err = checkDistinct(node, groups, fields, p.router, tbInfos, !hasAggregates && ok); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If the group by fields contain shard key,  only need to push down the group by to backend. Neednot process on the radon.
Prerequisite:
1.The plannode is MergeNode.
2.Select list doesnot contain aggregate function.