### PR TITLE
planner: group by with aggregate optimization

### DIFF
--- a/src/planner/aggregate_plan_test.go
+++ b/src/planner/aggregate_plan_test.go
@@ -125,7 +125,7 @@ func TestAggregatePlan(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -253,7 +253,7 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -310,7 +310,7 @@ func TestAggregatePlanHaving(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build
@@ -356,7 +356,7 @@ func TestAggregatePlanUnsupported(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), ok)
 		if err == nil {
 			plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 			err := plan.Build()
@@ -427,7 +427,7 @@ func TestAggregatePlans(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, hasAgg)
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(node.GroupBy, tuples, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		plan := NewAggregatePlan(log, node.SelectExprs, tuples, groups)
 		// plan build

--- a/src/planner/expr_test.go
+++ b/src/planner/expr_test.go
@@ -217,11 +217,11 @@ func TestCheckGroupBy(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		assert.Equal(t, wants[i], len(groups))
 	}
@@ -256,11 +256,11 @@ func TestCheckGroupByError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
 		_, ok := p.(*MergeNode)
-		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
+		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), ok)
 		got := err.Error()
 		assert.Equal(t, wants[i], got)
 	}
@@ -295,10 +295,11 @@ func TestCheckDistinct(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
+
 		_, ok := p.(*MergeNode)
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), !hasAgg && ok)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 		assert.Equal(t, wants[i], len(sel.GroupBy))
 	}
@@ -331,10 +332,11 @@ func TestCheckDistinctError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
+
 		_, ok := p.(*MergeNode)
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), !hasAgg && ok)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferredTables(), ok)
 		got := err.Error()
 		assert.Equal(t, wants[i], got)
 	}
@@ -364,11 +366,11 @@ func TestSelectExprs(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, false)
@@ -407,11 +409,11 @@ func TestSelectExprsError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, false)
@@ -428,11 +430,11 @@ func TestSelectExprsError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		fields, hasAgg, err := parserSelectExprs(sel.SelectExprs, p)
+		fields, _, err := parserSelectExprs(sel.SelectExprs, p)
 		assert.Nil(t, err)
 
 		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), !hasAgg && ok)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferredTables(), ok)
 		assert.Nil(t, err)
 
 		err = p.pushSelectExprs(fields, groups, sel, true)

--- a/src/planner/merge_node.go
+++ b/src/planner/merge_node.go
@@ -165,6 +165,13 @@ func (m *MergeNode) pushSelectExprs(fields, groups []selectTuple, sel *sqlparser
 	m.Sel.SelectExprs = sel.SelectExprs
 	m.Sel.GroupBy = sel.GroupBy
 	m.Sel.Distinct = sel.Distinct
+
+	// eg: select id,sum(a) from tb group by id;
+	// id is tb's shard key. neednot build aggrPlan.
+	if len(groups) == 0 && len(sel.GroupBy) > 0 {
+		return nil
+	}
+
 	if hasAggregates || len(groups) > 0 {
 		aggrPlan := NewAggregatePlan(m.log, m.Sel.SelectExprs, fields, groups)
 		if err := aggrPlan.Build(); err != nil {

--- a/src/planner/select_plan.go
+++ b/src/planner/select_plan.go
@@ -124,11 +124,11 @@ func (p *SelectPlan) Build() error {
 		return err
 	}
 
-	if groups, err = checkGroupBy(node.GroupBy, fields, p.router, tbInfos, !hasAggregates && ok); err != nil {
+	if groups, err = checkGroupBy(node.GroupBy, fields, p.router, tbInfos, ok); err != nil {
 		return err
 	}
 
-	if groups, err = checkDistinct(node, groups, fields, p.router, tbInfos, !hasAggregates && ok); err != nil {
+	if groups, err = checkDistinct(node, groups, fields, p.router, tbInfos, ok); err != nil {
 		return err
 	}
 

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -108,13 +108,7 @@ func TestSelectPlan(t *testing.T) {
 			"Range": "[512-4096)"
 		}
 	],
-	"Aggregate": [
-		"A"
-	],
 	"GatherMerge": [
-		"id"
-	],
-	"HashGroupBy": [
 		"id"
 	]
 }`,
@@ -351,13 +345,7 @@ func TestSelectPlanDatabaseIsNull(t *testing.T) {
 			"Range": "[512-4096)"
 		}
 	],
-	"Aggregate": [
-		"A"
-	],
 	"GatherMerge": [
-		"id"
-	],
-	"HashGroupBy": [
 		"id"
 	]
 }`,


### PR DESCRIPTION
https://github.com/radondb/radon/pull/341

group by with shard key,  at the same time contain aggregate function, such as (a is shard key): 
```
select a,count(b) from tb3 group by a;
```
we neednot process group by and count on radon.

```
mysql> explain select a,count(b) from tb3 group by a;
+-------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+-------------------------------------------------------------------------------------+
| {
        "RawQuery": " select a,count(b) from tb3 group by a",
        "Project": "a, count(b)",
        "Partitions": [
                {
                        "Query": "select a, count(b) from zzq.tb3_0000 as tb3 group by a order by a asc",
                        "Backend": "backend1",
                        "Range": "[0-64)"
                },
                {
                        "Query": "select a, count(b) from zzq.tb3_0001 as tb3 group by a order by a asc",
                        "Backend": "backend1",
                        "Range": "[64-128)"
                },
                ... ...
        ],
        "GatherMerge": [
                "a"
        ]
} |
+-------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

```