### PR TITLE
planner: fix groupby and orderby return wrong results' bug #346

### DIFF
--- a/src/planner/aggregate_plan_test.go
+++ b/src/planner/aggregate_plan_test.go
@@ -95,7 +95,7 @@ func TestAggregatePlan(t *testing.T) {
 			"Type": "GROUP BY"
 		},
 		{
-			"Field": "b1",
+			"Field": "b",
 			"Index": 8,
 			"Type": "GROUP BY"
 		},
@@ -223,7 +223,7 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 			"Type": "GROUP BY"
 		},
 		{
-			"Field": "b1",
+			"Field": "b",
 			"Index": 8,
 			"Type": "GROUP BY"
 		},
@@ -377,7 +377,7 @@ func TestAggregatePlans(t *testing.T) {
 		`{
 	"Aggrs": [
 		{
-			"Field": "b1",
+			"Field": "avg(a)",
 			"Index": 0,
 			"Type": "AVG"
 		},

--- a/src/planner/expr_test.go
+++ b/src/planner/expr_test.go
@@ -192,13 +192,17 @@ func TestCheckGroupBy(t *testing.T) {
 		"select A.id as a from A group by a",
 		"select A.id+G.id as id from A,G group by id",
 		"select A.id from A group by id",
+		"select id as a from A group by id",
+		"select id as a from A group by A.id",
 	}
 	wants := []int{
 		1,
 		2,
-		2,
+		0,
+		0,
 		1,
-		1,
+		0,
+		0,
 		0,
 	}
 
@@ -237,7 +241,7 @@ func TestCheckGroupByError(t *testing.T) {
 	}
 	wants := []string{
 		"unsupported: unknow.table.in.group.by.field[B.a]",
-		"unsupported: group.by.field.have.expression",
+		"unsupported: group.by.[1].type.should.be.colname",
 		"unsupported: group.by.field[id].should.be.in.select.list",
 	}
 
@@ -390,7 +394,7 @@ func TestSelectExprsError(t *testing.T) {
 		"select A.id,G.a as a, concat(A.str,B.str) from A join B on A.id=B.id join G on A.a=G.a",
 	}
 	wants := []string{
-		"unsupported: group.by.field[s].should.be.in.noaggregate.select.list",
+		"unsupported: group.by.field[sum(A.id)].should.be.in.noaggregate.select.list",
 		"unsupported: expr.'concat(B.str, G.str)'.in.cross-shard.join",
 		"unsupported: expr.'concat(A.str, B.str)'.in.cross-shard.join",
 	}
@@ -559,7 +563,7 @@ func TestPushOrderByError(t *testing.T) {
 	}
 	wants := []string{
 		"unsupported: orderby[b].should.in.select.list",
-		"unsupported: orderby[b].should.in.select.list",
+		"unsupported: orderby[B.b].should.in.select.list",
 		"unsupported: unknow.table.in.order.by.field[C.a]",
 	}
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))

--- a/src/planner/orderby_plan_test.go
+++ b/src/planner/orderby_plan_test.go
@@ -24,9 +24,12 @@ func TestOrderByPlan(t *testing.T) {
 		"select a,*,c,d from A order by a asc",
 		"select a as b,c,d from A order by b desc",
 		"select A.* from A order by A.a",
+		"select A.* from A order by a",
 		"select * from A order by A.a",
 		"select a from A order by A.a",
 		"select A.a from A order by a",
+		"select a as b from A order by a",
+		"select a as b from A order by A.a",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
@@ -61,7 +64,7 @@ func TestOrderByPlanError(t *testing.T) {
 	}
 	results := []string{
 		"unsupported: orderby[c].should.in.select.list",
-		"unsupported: orderby:&{Qualifier: Name:rand Distinct:false Exprs:[]}",
+		"unsupported: orderby:[rand()].type.should.be.colname",
 		"unsupported: unknow.table.in.order.by.field[X.a]",
 	}
 

--- a/src/planner/plan_node.go
+++ b/src/planner/plan_node.go
@@ -85,9 +85,11 @@ func procure(tbInfos map[string]*TableInfo, col *sqlparser.ColName) string {
 	tuples := node.getFields()
 	index := -1
 	for i, tuple := range tuples {
-		if len(tuple.referTables) == 1 && table == tuple.referTables[0] && field == tuple.field {
-			index = i
-			break
+		if tuple.isCol {
+			if field == tuple.field && table == tuple.referTables[0] {
+				index = i
+				break
+			}
 		}
 	}
 	// key not in the select fields.


### PR DESCRIPTION
```
mysql> select a as b from t1 order by a;
+---+
| b |
+---+
| 1 |
| 2 |
| 3 |
| 4 |
| 5 |
+---+
5 rows in set (1.19 sec)

mysql> select a as b from t1 order by t1.a;
+---+
| b |
+---+
| 1 |
| 2 |
| 3 |
| 4 |
| 5 |
+---+
5 rows in set (1.06 sec)

mysql> select a as b from t1 order by t1.b;
ERROR 1105 (HY000): unsupported: orderby[t1.b].should.in.select.list
mysql> select a as b from t1 order by b;
+---+
| b |
+---+
| 1 |
| 2 |
| 3 |
| 4 |
| 5 |
+---+
5 rows in set (1.06 sec)

mysql> select a,b from t1 order by b;
+---+------+
| a | b    |
+---+------+
| 3 | a    |
| 1 | b    |
| 4 | b    |
| 2 | c    |
| 5 | d    |
+---+------+
5 rows in set (1.09 sec)
```