### PR TITLE
fix the access denied error to support lower version auth, fixe the #27 

### DIFF
--- a/src/proxy/auth.go
+++ b/src/proxy/auth.go
@@ -80,23 +80,27 @@ func (spanner *Spanner) AuthCheck(s *driver.Session) error {
 	// Client response.
 	resp := s.Scramble()
 
+	//set default version to 5.7
+	version := 5.7
 	// Diff query for different MySQL version
 	versionQuery := fmt.Sprintf("select left(version(), 3) as version")
 	vr, err := spanner.ExecuteSingle(versionQuery)
 	if err != nil {
-		log.Error("proxy: get MySQL version error:%+v", err)
-		return sqldb.NewSQLErrorf(sqldb.CR_VERSION_ERROR, "Cann't get MySQL version '%v'", user)
-	}
-	versionStr := vr.Rows[0][0].String();
-	version, err := strconv.ParseFloat(versionStr, 64)
-	if err != nil {
-		log.Error("proxy: convert version to number error:%+v", err)
+		log.Info("proxy: get MySQL version error:%+v", err)
+	} else {
+		if len(vr.Rows) == 0 {
+			log.Error("proxy: can not get MySQL version")
+			return sqldb.NewSQLErrorf(sqldb.ER_ACCESS_DENIED_ERROR, "Access denied for user '%v'", user)
+		}
+		versionStr := vr.Rows[0][0].String();
+		version, err = strconv.ParseFloat(versionStr, 64)
+		if err != nil {
+			log.Error("proxy: convert version to number error:%+v", err)
+		}
 	}
 
-	var query string
-	if (version > 5.6) {
-		query = fmt.Sprintf("select authentication_string from mysql.user where user='%s'", user)
-	} else {
+	query := fmt.Sprintf("select authentication_string from mysql.user where user='%s'", user)
+	if (version < 5.7) {
 		query = fmt.Sprintf("select password as authentication_string from mysql.user where user='%s'", user)
 	}
 


### PR DESCRIPTION
The `mysql password string` are store in different `fileds` of the `mysql.user` table in different MySQL version, so we need read `password` field from lower MySQL version:

| version | filed |
:--:|:--:
| v5.1 | password |
| v5.5 | password, authentication_string(empty) |
| v5.6 | password, authentication_string(empty) |
| v5.7 | authentication_string |
| v8.0 | authentication_string |