### PR TITLE
codecov: enable the codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,13 @@
 coverage:
-  precision: 2
+  precision: 0
   round: down
   range: "70...100"
+  status:
+    project:
+      default:
+        enabled: yes
+        threshold: 1%
+    patch:
+      default:
+        enabled: yes
+        threshold: 1%


### PR DESCRIPTION
[summary]
1. change the precision from 2 to 0 (xx%)
2. allowed to drop 1% and still result in a success commit status

[test case]
N/A

[patch codecov]
N/A