### PR TITLE
proxy: remove router.db when create db fail #484

### DIFF
--- a/src/proxy/ddl.go
+++ b/src/proxy/ddl.go
@@ -192,7 +192,13 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 		if err := route.CreateDatabase(database); err != nil {
 			return nil, err
 		}
-		return spanner.ExecuteScatter(query)
+		qr, err := spanner.ExecuteScatter(query)
+		if err != nil {
+			// If we got err, try to drop database.
+			route.DropDatabase(database)
+			return nil, err
+		}
+		return qr, nil
 	case sqlparser.DropDBStr:
 		if node.IfExists && !checkDatabaseExists(database, route) {
 			return &sqltypes.Result{}, nil


### PR DESCRIPTION
[summary]
Currently we create a database like "create db1"

[test case]
proxy/ddl_test.go

[patch codecov]
proxy/ddl.go 94%