### PR TITLE
*: add backend version to the serverversion #495

### DIFF
--- a/src/fakedb/fakedb.go
+++ b/src/fakedb/fakedb.go
@@ -226,7 +226,7 @@ func (db *DB) ResetErrors() {
 
 // addMockUser adds mock/mock user to mysql.user table.
 func (db *DB) addMockUser() {
-	resultVersion57 := &sqltypes.Result{
+	resultVersion570 := &sqltypes.Result{
 		RowsAffected: 1,
 		Fields: []*querypb.Field{
 			{
@@ -236,7 +236,7 @@ func (db *DB) addMockUser() {
 		},
 		Rows: [][]sqltypes.Value{
 			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("5.7")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("5.7.0")),
 			},
 		},
 	}
@@ -255,7 +255,7 @@ func (db *DB) addMockUser() {
 		},
 	}
 
-	db.AddQuery("select left(version(), 3) as version", resultVersion57)
+	db.AddQuery("select version() as version", resultVersion570)
 	db.AddQuery("select authentication_string from mysql.user where user='mock'", r1)
 	// Multiple users for the privilege.
 	db.AddQuery("select authentication_string from mysql.user where user='mock1'", r1)

--- a/src/proxy/auth.go
+++ b/src/proxy/auth.go
@@ -14,15 +14,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	"github.com/xelabs/go-mysqlstack/driver"
 	"github.com/xelabs/go-mysqlstack/sqldb"
-)
-
-const (
-	defaultMySQLVersion = 5.7
 )
 
 func localHostLogin(host string) bool {
@@ -84,26 +79,14 @@ func (spanner *Spanner) AuthCheck(s *driver.Session) error {
 	// Client response.
 	resp := s.Scramble()
 
-	// Get the backend MySQL version
-	versionQuery := fmt.Sprintf("select left(version(), 3) as version")
-	vr, err := spanner.ExecuteSingle(versionQuery)
-	if err != nil || len(vr.Rows) == 0 {
-		log.Error("proxy: get MySQL version error:%+v", err)
-		return sqldb.NewSQLErrorf(sqldb.CR_VERSION_ERROR, "Cann't get MySQL version '%v'", user)
-	}
-	version := defaultMySQLVersion
-	versionStr := vr.Rows[0][0].String()
-	version, err = strconv.ParseFloat(versionStr, 64)
-	if err != nil {
-		log.Error("proxy: convert version to number error:%+v", err)
-	}
-
-	// Diff query for different MySQL version
+	// Diff query for different MySQL version.
 	var query string
-	if version < defaultMySQLVersion {
-		query = fmt.Sprintf("select password as authentication_string from mysql.user where user='%s'", user)
-	} else {
+	versionStr := spanner.ServerVersion()
+	version, _ := parseVersionString(versionStr, false)
+	if version.atLeast(authenticationMySQLVersion) {
 		query = fmt.Sprintf("select authentication_string from mysql.user where user='%s'", user)
+	} else {
+		query = fmt.Sprintf("select password as authentication_string from mysql.user where user='%s'", user)
 	}
 
 	qr, err := spanner.ExecuteSingle(query)

--- a/src/proxy/version.go
+++ b/src/proxy/version.go
@@ -1,0 +1,94 @@
+package proxy
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/xelabs/go-mysqlstack/sqldb"
+)
+
+var (
+	defaultMySQLVersionStr     = "5.7.25"
+	defaultMySQLVersion        = serverVersion{5, 7, 25, ""}
+	authenticationMySQLVersion = serverVersion{5, 7, 0, ""}
+	versionRegex               = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
+)
+
+type serverVersion struct {
+	Major, Minor, Patch int
+	Tag                 string
+}
+
+func (v *serverVersion) atLeast(compare serverVersion) bool {
+	if v.Major > compare.Major {
+		return true
+	}
+	if v.Major == compare.Major && v.Minor > compare.Minor {
+		return true
+	}
+	if v.Major == compare.Major && v.Minor == compare.Minor && v.Patch >= compare.Patch {
+		return true
+	}
+	return false
+}
+
+func (v *serverVersion) equal(compare serverVersion) bool {
+	if v.Major == compare.Major && v.Minor == compare.Minor && v.Patch == compare.Patch {
+		return true
+	}
+	return false
+}
+
+func (v *serverVersion) toStr() string {
+	vStr := strconv.Itoa(v.Major) + "." + strconv.Itoa(v.Minor) + "." + strconv.Itoa(v.Patch) + "-" + v.Tag
+	return vStr
+}
+
+// parseVersionString parse the string of version.
+func parseVersionString(version string, withTag bool) (ver serverVersion, err error) {
+	if withTag {
+		versions := strings.SplitN(version, "-", 2)
+		if len(versions) > 1 {
+			ver.Tag = versions[1]
+		}
+	}
+
+	v := versionRegex.FindStringSubmatch(version)
+	if len(v) != 4 {
+		return ver, fmt.Errorf("could not parse server version from: %s", version)
+	}
+	ver.Major, err = strconv.Atoi(string(v[1]))
+	if err != nil {
+		return ver, fmt.Errorf("could not parse server version from: %s", version)
+	}
+	ver.Minor, err = strconv.Atoi(string(v[2]))
+	if err != nil {
+		return ver, fmt.Errorf("could not parse server version from: %s", version)
+	}
+	ver.Patch, err = strconv.Atoi(string(v[3]))
+	if err != nil {
+		return ver, fmt.Errorf("could not parse server version from: %s", version)
+	}
+	return
+}
+
+// getBackendVersion get the backend MySQL version
+func getBackendVersion(spanner *Spanner) (version serverVersion, err error) {
+	log := spanner.log
+	versionQuery := fmt.Sprintf("select version() as version")
+	vr, err := spanner.ExecuteSingle(versionQuery)
+	if err != nil || len(vr.Rows) == 0 {
+		log.Error("proxy: get MySQL version error:%+v", err)
+		return version, sqldb.NewSQLErrorf(sqldb.CR_VERSION_ERROR, "Cann't get MySQL version")
+	}
+
+	versionStr := vr.Rows[0][0].String()
+	backendVersion, err := parseVersionString(versionStr, false)
+	if err != nil {
+		log.Error("proxy: parse MySQL version error:%+v", err)
+		return version, sqldb.NewSQLErrorf(sqldb.CR_VERSION_ERROR, "Cann't get MySQL version")
+	}
+	return backendVersion, nil
+}

--- a/src/proxy/version_test.go
+++ b/src/proxy/version_test.go
@@ -1,0 +1,120 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xelabs/go-mysqlstack/driver"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+	"github.com/xelabs/go-mysqlstack/xlog"
+)
+
+type testcase struct {
+	versionString string
+	withTag       bool
+	version       serverVersion
+}
+
+func TestVersionParseString(t *testing.T) {
+	var testcases = []testcase{
+		{
+			versionString: "5.7.20-18-debug-log",
+			withTag:       false,
+			version:       serverVersion{5, 7, 20, ""},
+		},
+		{
+			versionString: "8.0.16-18-debug-log",
+			withTag:       false,
+			version:       serverVersion{8, 0, 16, ""},
+		},
+		{
+			versionString: "5.7.25-v1.0.7.2-26-gbbd35bf",
+			withTag:       true,
+			version:       serverVersion{5, 7, 25, "v1.0.7.2-26-gbbd35bf"},
+		},
+	}
+
+	var failedcases = []testcase{
+		{
+			versionString: "8.0.",
+			withTag:       false,
+			version:       serverVersion{8, 0, 16, ""},
+		},
+	}
+
+	for _, testcase := range testcases {
+		v, err := parseVersionString(testcase.versionString, testcase.withTag)
+		assert.Nil(t, err)
+		assert.Equal(t, testcase.version, v)
+	}
+
+	for _, testcase := range failedcases {
+		_, err := parseVersionString(testcase.versionString, testcase.withTag)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestVersionSetServerVersion(t *testing.T) {
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	fakedbs, proxy, cleanup := MockProxy(log)
+	defer cleanup()
+	address := proxy.Address()
+
+	// fakedbs.
+	{
+		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
+		fakedbs.AddQueryPattern("show databases", &sqltypes.Result{})
+		fakedbs.AddQueryPattern("create .*", &sqltypes.Result{})
+	}
+
+	{
+		client, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.Nil(t, err)
+		defer client.Close()
+		// the new client with the same backend, the version won't be set.
+		client1, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.Nil(t, err)
+		defer client1.Close()
+	}
+
+	fakedbs.ResetAll()
+	fakedbs.AddQuery("select version() as version", resultVersion57)
+	{
+		_, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.NotNil(t, err)
+
+	}
+
+	fakedbs.ResetAll()
+	{
+		_, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.NotNil(t, err)
+	}
+}
+
+func TestVersionFunction(t *testing.T) {
+	MySQLVersion := serverVersion{5, 7, 25, ""}
+	MySQLVersion8 := serverVersion{8, 0, 3, ""}
+
+	MySQLVersions := []serverVersion {
+		{4, 0, 0, ""},
+		{5, 0, 0, ""},
+		{5, 6, 0, ""},
+		{5, 7, 0, ""},
+		{5, 7, 25, ""},
+	}
+	for _, Version := range MySQLVersions {
+		isAtLeast := MySQLVersion.atLeast(Version)
+		assert.Equal(t, true, isAtLeast)
+	}
+	isAtLeast := MySQLVersion.atLeast(MySQLVersion8)
+	assert.Equal(t, false, isAtLeast)
+
+	MySQLVersion6 := serverVersion{5, 7, 25, ""}
+	isEqual := MySQLVersion.equal(MySQLVersion6)
+	assert.Equal(t, true, isEqual)
+	isEqual = MySQLVersion.equal(MySQLVersion8)
+	assert.Equal(t, false, isEqual)
+
+	MySQLVersion.toStr()
+}

--- a/src/router/frm.go
+++ b/src/router/frm.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	TableTypeSingle    = "single"
-	TableTypeGlobal    = "global"
-	TableTypeUnknow    = "unknow"
+	TableTypeSingle = "single"
+	TableTypeGlobal = "global"
+	TableTypeUnknow = "unknow"
 
 	TableTypePartitionHash  = "hash"
 	TableTypePartitionList  = "list"

--- a/src/vendor/github.com/xelabs/go-mysqlstack/driver/mock.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/driver/mock.go
@@ -170,6 +170,11 @@ func (th *TestHandler) ServerVersion() string {
 	return "FakeDB"
 }
 
+// SetServerVersion implements the interface.
+func (th *TestHandler) SetServerVersion() {
+	return
+}
+
 // NewSession implements the interface.
 func (th *TestHandler) NewSession(s *Session) {
 	th.mu.Lock()

--- a/src/vendor/github.com/xelabs/go-mysqlstack/proto/statement_test.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/proto/statement_test.go
@@ -164,8 +164,8 @@ func TestStatementExecuteUnPackError(t *testing.T) {
 // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
 // test about new-params-bound-flag about 0 1
 func TestStatementExecuteBatchUnPackStatementExecute(t *testing.T) {
-	data := []byte{/*23,*/18, 0, 0, 0, 128, 1, 0, 0, 0, 0, 1, 1, 128, 1}
-	data2 := []byte{/*23,*/18, 0, 0, 0, 128, 1, 0, 0, 0, 0, 0, 1, 128, 1}
+	data := []byte{ /*23,*/ 18, 0, 0, 0, 128, 1, 0, 0, 0, 0, 1, 1, 128, 1}
+	data2 := []byte{ /*23,*/ 18, 0, 0, 0, 128, 1, 0, 0, 0, 0, 0, 1, 128, 1}
 
 	var dataBatch [][]byte
 	dataBatch = append(dataBatch, data)


### PR DESCRIPTION
[summary]
because some jdbc need the version of MySQL
add backend version to the serverversion
serverversion="$MySQL" + "-" + "$tag"

[test case]
src/proxy/version_test.go

[patch codecov]
src/proxy/version_test.go (92.7%)