### PR TITLE
proxy: fix the panic #495

### DIFF
--- a/src/proxy/query.go
+++ b/src/proxy/query.go
@@ -56,7 +56,9 @@ func (spanner *Spanner) ComQuery(session *driver.Session, query string, bindVari
 	// Support for JDBC/Others driver.
 	if spanner.isConnectorFilter(query) {
 		qr, err := spanner.handleJDBCShows(session, query, nil)
-		qr.Warnings = 1
+		if err == nil {
+			qr.Warnings = 1
+		}
 		return returnQuery(qr, callback, err)
 	}
 


### PR DESCRIPTION
[summary]
fix panic:
runtime error: invalid memory address or nil pointer dereference
[test case]
src/proxy/query_test.go
[patch codecov]
100%