### PR TITLE
sqlparser: replace and clone expression #441

### DIFF
--- a/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/ast_test.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/ast_test.go
@@ -168,6 +168,197 @@ func TestSetLimit(t *testing.T) {
 	}
 }
 
+func TestCloneSelectExpr(t *testing.T) {
+	tcases := []struct {
+		in, out string
+	}{
+		{
+			in:  "select * from t",
+			out: "*",
+		},
+		{
+			in:  "select next value from t",
+			out: "next 1 values",
+		},
+		{
+			in:  "select a from t",
+			out: "a",
+		},
+		{
+			in:  "select avg(distinct a) as tmp from t",
+			out: "avg(distinct a) as tmp",
+		},
+	}
+	for _, tcase := range tcases {
+		tree, err := Parse(tcase.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expr := CloneSelectExpr(tree.(*Select).SelectExprs[0])
+		got := String(expr)
+		if tcase.out != got {
+			t.Errorf("ReplaceExpr(%s): %s, want %s", tcase.in, got, tcase.out)
+		}
+	}
+}
+
+func TestCloneAndReplace(t *testing.T) {
+	tcases := []struct {
+		in, out string
+	}{{
+		in:  "select * from t where (select a from b)",
+		out: ":a",
+	}, {
+		in:  "select * from t where (select a from b) and b",
+		out: ":a and b",
+	}, {
+		in:  "select * from t where a and (select a from b)",
+		out: "a and :a",
+	}, {
+		in:  "select * from t where (select a from b) or b",
+		out: ":a or b",
+	}, {
+		in:  "select * from t where a or (select a from b)",
+		out: "a or :a",
+	}, {
+		in:  "select * from t where not (select a from b)",
+		out: "not :a",
+	}, {
+		in:  "select * from t where ((select a from b))",
+		out: "(:a)",
+	}, {
+		in:  "select * from t where (select a from b) = 1",
+		out: ":a = 1",
+	}, {
+		in:  "select * from t where a = (select a from b)",
+		out: "a = :a",
+	}, {
+		in:  "select * from t where a like b escape (select a from b)",
+		out: "a like b escape :a",
+	}, {
+		in:  "select * from t where (select a from b) between a and b",
+		out: ":a between a and b",
+	}, {
+		in:  "select * from t where a between (select a from b) and b",
+		out: "a between :a and b",
+	}, {
+		in:  "select * from t where a between b and (select a from b)",
+		out: "a between b and :a",
+	}, {
+		in:  "select * from t where (select a from b) is null",
+		out: ":a is null",
+	}, {
+		// exists should not replace.
+		in:  "select * from t where exists (select a from b)",
+		out: "exists (select a from b)",
+	}, {
+		in:  "select * from t where a in ((select a from b), 1)",
+		out: "a in (:a, 1)",
+	}, {
+		in:  "select * from t where a in (0, (select a from b), 1)",
+		out: "a in (0, :a, 1)",
+	}, {
+		in:  "select * from t where (select a from b) + 1",
+		out: ":a + 1",
+	}, {
+		in:  "select * from t where 1+(select a from b)",
+		out: "1 + :a",
+	}, {
+		in:  "select * from t where -(select a from b)",
+		out: "-:a",
+	}, {
+		in:  "select * from t where interval (select a from b) aa",
+		out: "interval :a aa",
+	}, {
+		in:  "select * from t where (select a from b) collate utf8",
+		out: ":a collate utf8",
+	}, {
+		in:  "select * from t where func((select a from b), 1)",
+		out: "func(:a, 1)",
+	}, {
+		in:  "select * from t where func(1, (select a from b), 1)",
+		out: "func(1, :a, 1)",
+	}, {
+		in:  "select * from t where group_concat((select a from b), 1 order by a)",
+		out: "group_concat(:a, 1 order by a asc)",
+	}, {
+		in:  "select * from t where group_concat(1 order by (select a from b), a)",
+		out: "group_concat(1 order by :a asc, a asc)",
+	}, {
+		in:  "select * from t where group_concat(1 order by a, (select a from b))",
+		out: "group_concat(1 order by a asc, :a asc)",
+	}, {
+		in:  "select * from t where substr(a, (select a from b), b)",
+		out: "substr(a, :a, b)",
+	}, {
+		in:  "select * from t where substr(a, b, (select a from b))",
+		out: "substr(a, b, :a)",
+	}, {
+		in:  "select * from t where convert((select a from b), json)",
+		out: "convert(:a, json)",
+	}, {
+		in:  "select * from t where convert((select a from b) using utf8)",
+		out: "convert(:a using utf8)",
+	}, {
+		in:  "select * from t where match((select a from b), 1) against (a)",
+		out: "match(:a, 1) against (a)",
+	}, {
+		in:  "select * from t where match(1, (select a from b), 1) against (a)",
+		out: "match(1, :a, 1) against (a)",
+	}, {
+		in:  "select * from t where match(1, a, 1) against ((select a from b))",
+		out: "match(1, a, 1) against (:a)",
+	}, {
+		in:  "select * from t where case (select a from b) when a then b when b then c else d end",
+		out: "case :a when a then b when b then c else d end",
+	}, {
+		in:  "select * from t where case a when (select a from b) then b when b then c else d end",
+		out: "case a when :a then b when b then c else d end",
+	}, {
+		in:  "select * from t where case a when b then (select a from b) when b then c else d end",
+		out: "case a when b then :a when b then c else d end",
+	}, {
+		in:  "select * from t where case a when b then c when (select a from b) then c else d end",
+		out: "case a when b then c when :a then c else d end",
+	}, {
+		in:  "select * from t where case a when b then c when d then c else (select a from b) end",
+		out: "case a when b then c when d then c else :a end",
+	}}
+	to := NewValArg([]byte(":a"))
+	for _, tcase := range tcases {
+		tree, err := Parse(tcase.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var from *Subquery
+		_ = Walk(func(node SQLNode) (kontinue bool, err error) {
+			if sq, ok := node.(*Subquery); ok {
+				from = sq
+				return false, nil
+			}
+			return true, nil
+		}, tree)
+		if from == nil {
+			t.Fatalf("from is nil for %s", tcase.in)
+		}
+		expr := ReplaceExpr(tree.(*Select).Where.Expr, from, to)
+		got := String(expr)
+		if tcase.out != got {
+			t.Errorf("ReplaceExpr(%s): %s, want %s", tcase.in, got, tcase.out)
+		}
+
+		if _, ok := expr.(*ExistsExpr); ok {
+			continue
+		}
+
+		newExpr := CloneExpr(expr)
+		got = String(newExpr)
+		if tcase.out != got {
+			t.Errorf("ReplaceExpr(%s): %s, want %s", tcase.in, got, tcase.out)
+		}
+	}
+}
+
 func TestWhere(t *testing.T) {
 	var w *Where
 	buf := NewTrackedBuffer(nil)


### PR DESCRIPTION
[summary]
In order to swap expression out of the subqueries, we need the ability to replace an expression with another.
The purpose of CloneExpr is to create a new expression based on the provided expression, which is used in JoinNode.
[test case]
src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/ast_test.go
[patch codecov]
86.1%