### PR TITLE
builder: refactor the selectTuple #441

### DIFF
--- a/src/planner/builder/common.go
+++ b/src/planner/builder/common.go
@@ -44,6 +44,15 @@ func checkTbInNode(referTables []string, tbInfos map[string]*tableInfo) bool {
 	return true
 }
 
+func isContainKey(a string, b []string) bool {
+	for _, c := range b {
+		if c == a {
+			return true
+		}
+	}
+	return false
+}
+
 // getIndex used to get index from router.
 func getIndex(router *router.Router, tbInfo *tableInfo, val *sqlparser.SQLVal) error {
 	idx, err := router.GetIndex(tbInfo.database, tbInfo.tableName, val)
@@ -95,7 +104,7 @@ func procure(tbInfos map[string]*tableInfo, col *sqlparser.ColName) string {
 	index := -1
 	for i, tuple := range tuples {
 		if tuple.isCol {
-			if field == tuple.field && table == tuple.referTables[0] {
+			if field == tuple.field && table == tuple.info.referTables[0] {
 				index = i
 				break
 			}
@@ -104,9 +113,10 @@ func procure(tbInfos map[string]*tableInfo, col *sqlparser.ColName) string {
 	// key not in the select fields.
 	if index == -1 {
 		tuple := selectTuple{
-			expr:        &sqlparser.AliasedExpr{Expr: col},
-			field:       field,
-			referTables: []string{table},
+			expr:  &sqlparser.AliasedExpr{Expr: col},
+			info:  exprInfo{col, []string{table}, []*sqlparser.ColName{col}, nil},
+			field: field,
+			isCol: true,
 		}
 		index, _ = node.pushSelectExpr(tuple)
 	}

--- a/src/planner/builder/expr.go
+++ b/src/planner/builder/expr.go
@@ -57,10 +57,8 @@ func parserWhereOrJoinExprs(exprs sqlparser.Expr, tbInfos map[string]*tableInfo)
 					}
 				}
 
-				for _, tb := range referTables {
-					if tb == tableName {
-						return true, nil
-					}
+				if isContainKey(tableName, referTables) {
+					return true, nil
 				}
 				referTables = append(referTables, tableName)
 			case *sqlparser.Subquery:
@@ -272,10 +270,8 @@ func getTbInExpr(expr sqlparser.Expr) []string {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
 			tableName := node.Qualifier.Name.String()
-			for _, tb := range referTables {
-				if tb == tableName {
-					return true, nil
-				}
+			if isContainKey(tableName, referTables) {
+				return true, nil
 			}
 			referTables = append(referTables, tableName)
 		}
@@ -339,10 +335,9 @@ func parserHaving(exprs sqlparser.Expr, tbInfos map[string]*tableInfo) ([]exprIn
 						return false, errors.Errorf("unsupported: unknown.table.'%s'.in.having.clause", tableName)
 					}
 				}
-				for _, tb := range referTables {
-					if tb == tableName {
-						return true, nil
-					}
+
+				if isContainKey(tableName, referTables) {
+					return true, nil
 				}
 				referTables = append(referTables, tableName)
 			case *sqlparser.FuncExpr:


### PR DESCRIPTION
[summary]
Add info into selectTuple, to record the cols|refertable|expr from selectexpr.
When pushselectexpr during process subquery, we need replace the cols with fields in subquery.
[test case]
N/A
[patch codecov]
N/A