### PR TITLE
planner: rewrite parseHaving function #520

### DIFF
--- a/src/planner/builder/builder.go
+++ b/src/planner/builder/builder.go
@@ -93,7 +93,7 @@ func processSelect(log *xlog.Log, router *router.Router, database string, node *
 	}
 
 	if node.Having != nil {
-		havings, err := parseHaving(node.Having.Expr, tbInfos)
+		havings, err := parseHaving(node.Having.Expr, tbInfos, root.getFields())
 		if err != nil {
 			return nil, err
 		}

--- a/src/planner/builder/builder_test.go
+++ b/src/planner/builder/builder_test.go
@@ -61,41 +61,40 @@ func TestProcessSelect(t *testing.T) {
 				}},
 		},
 		{
-			query:   "select id, sum(a) as A from A group by id having A>1000",
+			query:   "select id, sum(a) as A from A group by id having id>1000",
 			project: "id, A",
 			out: []xcontext.QueryTuple{
 				{
-					Query:   "select id, sum(a) as A from sbtest.A1 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A1 as A group by id having id > 1000 order by id asc",
 					Backend: "backend1",
 					Range:   "[0-32)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A2 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A2 as A group by id having id > 1000 order by id asc",
 					Backend: "backend2",
 					Range:   "[32-64)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A3 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A3 as A group by id having id > 1000 order by id asc",
 					Backend: "backend3",
 					Range:   "[64-96)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A4 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A4 as A group by id having id > 1000 order by id asc",
 					Backend: "backend4",
 					Range:   "[96-256)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A5 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A5 as A group by id having id > 1000 order by id asc",
 					Backend: "backend5",
 					Range:   "[256-512)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A6 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A6 as A group by id having id > 1000 order by id asc",
 					Backend: "backend6",
 					Range:   "[512-4096)",
 				}},
 		},
-
 		{
 			query:   "select id,a from sbtest.A where (a>1 and (id=1))",
 			project: "id, a",
@@ -409,35 +408,35 @@ func TestSelectDatabaseIsNull(t *testing.T) {
 				}},
 		},
 		{
-			query: "select id, sum(a) as A from sbtest.A group by id having A>1000",
+			query: "select id, sum(a) as A from sbtest.A group by id having id>1000",
 			out: []xcontext.QueryTuple{
 				{
-					Query:   "select id, sum(a) as A from sbtest.A1 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A1 as A group by id having id > 1000 order by id asc",
 					Backend: "backend1",
 					Range:   "[0-32)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A2 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A2 as A group by id having id > 1000 order by id asc",
 					Backend: "backend2",
 					Range:   "[32-64)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A3 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A3 as A group by id having id > 1000 order by id asc",
 					Backend: "backend3",
 					Range:   "[64-96)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A4 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A4 as A group by id having id > 1000 order by id asc",
 					Backend: "backend4",
 					Range:   "[96-256)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A5 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A5 as A group by id having id > 1000 order by id asc",
 					Backend: "backend5",
 					Range:   "[256-512)",
 				},
 				{
-					Query:   "select id, sum(a) as A from sbtest.A6 as A group by id having A > 1000 order by id asc",
+					Query:   "select id, sum(a) as A from sbtest.A6 as A group by id having id > 1000 order by id asc",
 					Backend: "backend6",
 					Range:   "[512-4096)",
 				}},
@@ -499,7 +498,7 @@ func TestSelectUnsupported(t *testing.T) {
 		"select A.id from A join B on A.id = B.id join G on A.id+B.id<=G.id",
 		"select A.id from G join (A,B) on A.id+B.id<=G.id",
 		"select A.id from G join (A,B) on G.id<=A.id+B.id",
-		"select A.id as tmp, B.id from A,B having tmp=1",
+		"select sum(A.id) as tmp, B.id from A,B having tmp=1",
 		"select COALESCE(B.b, ''), IF(B.b IS NULL, FALSE, TRUE) AS spent from A left join B on A.a=B.a",
 		"select A.a as b from A order by A.b",
 		"select a+1 from A order by a+1",
@@ -537,7 +536,7 @@ func TestSelectUnsupported(t *testing.T) {
 		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
 		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
 		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
-		"unsupported: unknown.column.'tmp'.in.having.clause",
+		"unsupported: aggregation.in.having.clause",
 		"unsupported: expr.'COALESCE(B.b, '')'.in.cross-shard.left.join",
 		"unsupported: orderby[A.b].should.in.select.list",
 		"unsupported: orderby:[a + 1].type.should.be.colname",
@@ -573,7 +572,7 @@ func TestSelectUnsupported(t *testing.T) {
 
 func TestSelectSupported(t *testing.T) {
 	querys := []string{
-		"select id,rand(id) from A",
+		"select id,rand(id),str1,str2 from A having concat(str1,str2) is null",
 		"select now() as time, count(1), avg(id), sum(b) from A",
 		"select avg(id + 1) from A",
 		"select concat(str1,str2) from A",
@@ -594,7 +593,7 @@ func TestSelectSupported(t *testing.T) {
 		"select /*+nested+*/ A.id from G join (A,B) on A.id+B.id<=G.id",
 		"select /*+nested+*/ A.id from G join (A,B) on G.id<=A.id+B.id",
 		"select /*+nested+*/ sum(A.id) from A join B on A.id=B.id",
-		"select /*+nested+*/ A.id from G,A,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
+		"select /*+nested+*/ B.id,G.id,B.a from G,A,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
 		"select COALESCE(A.b, ''), IF(A.b IS NULL, FALSE, TRUE) AS spent from A left join B on A.a=B.a",
 		"select COALESCE(B.b, ''), IF(B.b IS NULL, FALSE, TRUE) AS spent from A join B on A.a=B.a",
 		"select A.id from A left join B on B.id+1=A.id where B.str1+B.str2 is null",
@@ -1140,7 +1139,6 @@ func TestSelectSupportedPlanList(t *testing.T) {
 		"select A.id from A left join L on A.id=L.id where null<=>L.str",
 		"select A.id from A join L on A.id >= L.id join G on G.id<=A.id",
 		"select L.id from L join B on L.id >= B.id join G on G.id<=L.id",
-
 		"select /*+nested+*/ A.id from A join L on A.id=L.id right join G on G.id=L.id and A.a>L.a",
 		"select /*+nested+*/ A.id from (A,L) left join G on A.id =G.id and A.a>L.a",
 		"select /*+nested+*/ A.id from A join L on A.id=L.id right join G on G.id=A.id where concat(L.str,A.str) is null",
@@ -1150,7 +1148,6 @@ func TestSelectSupportedPlanList(t *testing.T) {
 		"select /*+nested+*/ A.id from G join (A,L) on A.id+L.id<=G.id",
 		"select /*+nested+*/ A.id from G join (A,L) on G.id<=A.id+L.id",
 		"select /*+nested+*/ sum(A.id) from A join L on A.id=L.id",
-		"select /*+nested+*/ A.id from G,A,L where A.id=L.id having G.id=L.id and L.a=1 and 1=1",
 		"select COALESCE(L.b, ''), IF(L.b IS NULL, FALSE, TRUE) AS spent from L left join B on L.a=B.a",
 		"select COALESCE(L.b, ''), IF(L.b IS NULL, FALSE, TRUE) AS spent from A join L on A.a=L.a",
 	}

--- a/src/planner/builder/expr.go
+++ b/src/planner/builder/expr.go
@@ -9,6 +9,8 @@
 package builder
 
 import (
+	"fmt"
+
 	"router"
 
 	"github.com/pkg/errors"
@@ -295,34 +297,37 @@ func checkJoinOn(lpn, rpn PlanNode, join exprInfo) (exprInfo, error) {
 }
 
 // parseHaving used to check the having exprs and parse into tuples.
-// unsupport: `select t2.id as tmp, t1.id from t2,t1 having tmp=1`.
-func parseHaving(exprs sqlparser.Expr, tbInfos map[string]*tableInfo) ([]exprInfo, error) {
-	filters := splitAndExpression(nil, exprs)
+// unsupport: `select sum(t2.id) as tmp, t1.id from t2,t1 having tmp=1`.
+func parseHaving(exprs sqlparser.Expr, tbInfos map[string]*tableInfo, fields []selectTuple) ([]exprInfo, error) {
 	var tuples []exprInfo
-
+	filters := splitAndExpression(nil, exprs)
 	for _, filter := range filters {
 		filter = skipParenthesis(filter)
-		referTables := make([]string, 0, 4)
+		tuple := exprInfo{filter, nil, nil, nil}
 		err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 			switch node := node.(type) {
 			case *sqlparser.ColName:
+				tuple.cols = append(tuple.cols, node)
 				tableName := node.Qualifier.Name.String()
-				if tableName == "" {
-					if len(tbInfos) == 1 {
-						tableName, _ = getOneTableInfo(tbInfos)
-					} else {
-						return false, errors.Errorf("unsupported: unknown.column.'%s'.in.having.clause", node.Name.String())
+				colName := node.Name.String()
+				inField, field := checkInTuple(colName, tableName, fields)
+				if !inField {
+					col := colName
+					if tableName != "" {
+						col = fmt.Sprintf("%s.%s", tableName, colName)
 					}
-				} else {
-					if _, ok := tbInfos[tableName]; !ok {
-						return false, errors.Errorf("unsupported: unknown.table.'%s'.in.having.clause", tableName)
-					}
+					return false, errors.Errorf("unsupported: unknown.column.'%s'.in.having.clause", col)
+				}
+				if field.aggrFuc != "" {
+					return false, errors.Errorf("unsupported: aggregation.in.having.clause")
 				}
 
-				if isContainKey(tableName, referTables) {
-					return true, nil
+				for _, tb := range field.info.referTables {
+					if isContainKey(tb, tuple.referTables) {
+						continue
+					}
+					tuple.referTables = append(tuple.referTables, tb)
 				}
-				referTables = append(referTables, tableName)
 			case *sqlparser.FuncExpr:
 				if node.IsAggregate() {
 					buf := sqlparser.NewTrackedBuffer(nil)
@@ -336,7 +341,6 @@ func parseHaving(exprs sqlparser.Expr, tbInfos map[string]*tableInfo) ([]exprInf
 			return nil, err
 		}
 
-		tuple := exprInfo{filter, referTables, nil, nil}
 		tuples = append(tuples, tuple)
 	}
 

--- a/src/planner/builder/expr_test.go
+++ b/src/planner/builder/expr_test.go
@@ -433,9 +433,10 @@ func TestSelectExprsError(t *testing.T) {
 func TestParserHaving(t *testing.T) {
 	querys := []string{
 		"select * from A where A.id=1 having concat(str1,str2) = 'sansi'",
-		"select * from G, A where G.id=A.id having A.id=1",
-		"select * from A, B where A.id=B.id having A.a=1 and 1=1",
-		"select * from A,G,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
+		"select A.id from G, A where G.id=A.id having A.id=1",
+		"select A.a from A, B where A.id=B.id having A.a=1 and 1=1",
+		"select G.id, B.id, B.a from A,G,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
+		"select A.a from A,B where A.id=1 having a>1",
 	}
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"
@@ -454,7 +455,13 @@ func TestParserHaving(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		havings, err := parseHaving(sel.Having.Expr, p.getReferTables())
+		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		err = p.pushSelectExprs(fields, nil, sel, aggTyp)
+		assert.Nil(t, err)
+
+		havings, err := parseHaving(sel.Having.Expr, p.getReferTables(), p.getFields())
 		assert.Nil(t, err)
 
 		err = p.pushHaving(havings)
@@ -464,16 +471,14 @@ func TestParserHaving(t *testing.T) {
 
 func TestParserHavingError(t *testing.T) {
 	querys := []string{
-		"select * from G,A,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
-		"select * from A,B where A.id=1 having sum(B.id)>10",
-		"select * from A,B where A.id=1 having a>1",
-		"select * from A,B where A.id=1 having C.a>1",
+		"select G.id, B.id, B.a from G,A,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
+		"select B.id from A,B where A.id=1 having sum(B.id)>10",
+		"select A.a from A,B where A.id=1 having C.a>1",
 	}
 	wants := []string{
 		"unsupported: havings.'G.id = B.id'.in.cross-shard.join",
 		"unsupported: expr[sum(B.id)].in.having.clause",
-		"unsupported: unknown.column.'a'.in.having.clause",
-		"unsupported: unknown.table.'C'.in.having.clause",
+		"unsupported: unknown.column.'C.a'.in.having.clause",
 	}
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"
@@ -492,7 +497,13 @@ func TestParserHavingError(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		havings, err := parseHaving(sel.Having.Expr, p.getReferTables())
+		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		err = p.pushSelectExprs(fields, nil, sel, aggTyp)
+		assert.Nil(t, err)
+
+		havings, err := parseHaving(sel.Having.Expr, p.getReferTables(), p.getFields())
 		if err != nil {
 			got := err.Error()
 			assert.Equal(t, wants[i], got)

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -74,36 +74,36 @@ func TestSelectPlan(t *testing.T) {
 	}
 }`,
 		`{
-	"RawQuery": "select id, sum(a) as A from A group by id having A\u003e1000",
+	"RawQuery": "select id, sum(a) as A from A group by id having id\u003e1000",
 	"Project": "id, A",
 	"Partitions": [
 		{
-			"Query": "select id, sum(a) as A from sbtest.A1 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A1 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend1",
 			"Range": "[0-32)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A2 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A2 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend2",
 			"Range": "[32-64)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A3 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A3 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend3",
 			"Range": "[64-96)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A4 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A4 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend4",
 			"Range": "[96-256)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A5 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A5 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend5",
 			"Range": "[256-512)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A6 as A group by id having A \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A6 as A group by id having id \u003e 1000 order by id asc",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}
@@ -421,7 +421,7 @@ func TestSelectPlan(t *testing.T) {
 	}
 	querys := []string{
 		"select 1, sum(a),avg(a),a,b from sbtest.A where id>1 group by a,b order by A.a desc limit 10 offset 100",
-		"select id, sum(a) as A from A group by id having A>1000",
+		"select id, sum(a) as A from A group by id having id>1000",
 		"select id,a from sbtest.A where (a>1 and (id=1))",
 		"select A.id,B.id from A join B on A.id=B.id where A.id=1",
 		"select A.id from A join B where A.id=1",


### PR DESCRIPTION
issue : #520
[summary]
Colname in having must be included in fields, need check in parseHaving.
[test case]
src/planner/builder/builder_test.go
src/planner/builder/expr_test.go
src/planner/select_plan_test.go
[patch codecov]
src/planner/builder 97.8%