### PR TITLE
*: change join strategy choice logic #480

### DIFF
--- a/src/executor/engine/join_engine_test.go
+++ b/src/executor/engine/join_engine_test.go
@@ -259,14 +259,14 @@ func TestJoinEngine(t *testing.T) {
 	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A2 as A order by A.name asc", r3)
 	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A4 as A order by A.name asc", r3)
 	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A8 as A order by A.name asc", r3)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name from sbtest.A8 as A where A.id = 2", r14)
+	fakedbs.AddQuery("select A.id, A.name from sbtest.A8 as A where A.id = 5", r14)
 	fakedbs.AddQuery("select A.id, A.name from sbtest.A8 as A where 1 != 1", r12)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name from sbtest.A8 as A where A.id = 3", r12)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A0 as A", r11)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A2 as A", r3)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A4 as A", r3)
-	fakedbs.AddQuery("select /*+nested+*/ A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A8 as A", r3)
-	fakedbs.AddQuery("select /*+nested+*/ G.a from sbtest.G", r4)
+	fakedbs.AddQuery("select A.id, A.name from sbtest.A8 as A where A.id = 3", r12)
+	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A0 as A", r11)
+	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A2 as A", r3)
+	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A4 as A", r3)
+	fakedbs.AddQuery("select A.id, A.name, A.id > 2 as tmpc_0 from sbtest.A8 as A", r3)
+	fakedbs.AddQuery("select G.a from sbtest.G", r4)
 
 	fakedbs.AddQuery("select B.name, B.id from sbtest.B0 as B", r21)
 	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B", r22)
@@ -278,19 +278,19 @@ func TestJoinEngine(t *testing.T) {
 	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id > 2 and B.name = 's' order by B.id asc", r21)
 	fakedbs.AddQuery("select B.name, B.id from sbtest.B0 as B where B.id > 2 order by B.id asc", r21)
 	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id > 2 order by B.id asc", r2)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.B1 as B where B.id = 1 and 'go' = B.name", r21)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.B1 as B where B.id = 1 and 'lang' = B.name", r2)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.B1 as B where B.id = 1 and 'niu' = B.name", r21)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.B1 as B where B.id = 1", r21)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.B1 as B where B.id = 1 and 'nice' = B.name", r21)
-	fakedbs.AddQuery("select /*+nested+*/ B.name, B.id from sbtest.b1 as b where b.id = 1 and 'nil' = b.name", r21)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id = 1 and 'go' + b.name = 'golang'", r21)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id = 1 and 'lang' + b.name = 'golang'", r2)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id = 1 and 'niu' + b.name = 'golang'", r21)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id = 1", r21)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.B1 as B where B.id = 1 and 'nice' + b.name = 'golang'", r21)
+	fakedbs.AddQuery("select B.name, B.id from sbtest.b1 as b where b.id = 1 and 'nil' + b.name = 'golang'", r21)
 	fakedbs.AddQuery("select b.name, b.id from sbtest.b1 as b where 1 != 1", r21)
 	fakedbs.AddQuery("select b.name, null + b.id as id from sbtest.b1 as b where 1 != 1", r21)
 
 	querys := []string{
 		"select A.id, B.name from A right join B on A.id=B.id where A.id > 2",
 		"select A.id, B.name from A join B on A.id=B.id where A.id > 2 limit 1",
-		"select A.id, B.name, B.id from A left join B on A.name=B.name and A.id > 2 order by A.id",
+		"select A.id, B.name, B.id, A.name from A left join B on A.name=B.name and A.id > 2 order by A.id",
 		"select A.id, B.name, B.id from A,B where A.id = 2",
 		"select A.id, B.name, B.id from A,B where A.id = 3",
 		"select A.id, B.name, B.id from B,A where A.id = 3",
@@ -303,16 +303,16 @@ func TestJoinEngine(t *testing.T) {
 		"select A.id, B.name, B.id, A.name from A join B on A.id<=B.id and A.name<=>B.name and A.id=2 and B.id=0 order by A.id",
 		"select A.id, B.name, B.id, A.name from A join B on A.id < B.id and A.name<=>B.name and A.id=2 and B.id=0 order by A.id",
 		"select A.id, B.name, B.id, A.name, A.id > 2 as tmpc_0 from A join B on A.name=B.name and A.id>=B.id and A.id > B.id order by A.id",
-		"select /*+nested+*/ A.id, B.name, B.id from A join B on A.name=B.name where A.id = 2 and B.id = 1 order by A.id limit 2",
-		"select /*+nested+*/ A.id, A.name, B.name, B.id from B join A on A.name=B.name where A.id = 2 and B.id = 1 order by A.id limit 1",
-		"select /*+nested+*/ A.id, B.name, B.id, A.name from A left join B on A.name=B.name and A.id>2 where B.name is null and B.id = 1 order by A.id",
-		"select /*+nested+*/ A.id, A.name, B.name, B.id from G,A,B where G.a=A.a and A.name=B.name and A.id=2 and B.id=1",
-		"select /*+nested+*/ B.name, A.id+B.id as id from A join B on A.name=B.name where A.id = 3",
+		"select A.id, B.name, B.id from A join B on A.name+B.name='golang' where A.id = 5 and B.id = 1 order by A.id limit 2",
+		"select A.id, A.name, B.name, B.id from B join A on A.name+B.name='golang' where A.id = 5 and B.id = 1 order by A.id limit 1",
+		"select A.id, B.name, B.id, A.name from A left join B on A.name+B.name='golang' and A.id>2 where B.name is null and B.id = 1 order by A.id",
+		"select A.id, A.name, B.name, B.id from G,A,B where G.a+A.a=1 and A.name=B.name and A.id=5 and B.id=1",
+		"select B.name, A.id+B.id as id from A join B on A.name=B.name where A.id = 3",
 	}
 	results := []string{
 		"[[3 go] [5 lang]]",
 		"[[3 go]]",
-		"[[3 go 3] [4  ] [5  ] [6  ] [6 lang 5]]",
+		"[[3 go 3 go] [4   lang] [5   nice] [6   nil] [6 lang 5 lang]]",
 		"[[3  3] [4  3] [5  3]]",
 		"[]",
 		"[]",
@@ -482,18 +482,18 @@ func TestMaxRowErr(t *testing.T) {
 	defer cleanup()
 	// desc
 	fakedbs.AddQuery("select a.id, a.name from sbtest.a8 as a where a.id = 3 order by a.id asc", r1)
-	fakedbs.AddQuery("select /*+nested+*/ a.id, a.name from sbtest.a8 as a where a.id = 3", r1)
-	fakedbs.AddQuery("select /*+nested+*/ b.id, b.name from sbtest.b1 as b where b.id = 3 and 3 = b.id", r1)
+	fakedbs.AddQuery("select a.id, a.name from sbtest.a8 as a where a.id = 3", r1)
+	fakedbs.AddQuery("select 3 + b.id as id, b.name from sbtest.b1 as b where b.id = 3 and 3 = b.id", r1)
 	fakedbs.AddQueryPattern("select b.id, b.name from .*", r2)
 	fakedbs.AddQueryPattern("select b.name, b.id from .*", r3)
 	fakedbs.AddQueryPattern("select s.id, s.name from .*", r1)
-	fakedbs.AddQueryPattern("select s.id, s.name = 'a' as tmpc_0 from .*", r4)
-	fakedbs.AddQueryPattern("select s.id, s.a = 'a' as tmpc_0 from .*", r5)
+	fakedbs.AddQueryPattern("select s.name = 'a' as tmpc_0, s.id from .*", r4)
+	fakedbs.AddQueryPattern("select s.a = 'a' as tmpc_0, s.id from .*", r5)
 
 	querys := []string{
 		"select A.id, A.name, B.name, B.id from A join B on A.id = B.id where A.id = 3",
 		"select S.id, S.name, B.id, B.name from S left join B on S.id = B.id and B.id = 2",
-		"select /*+nested+*/ A.id, A.name, B.id, B.name from A join B on A.id = B.id where A.id = 3",
+		"select A.id, A.name, A.id + B.id as id, B.name from A join B on A.id = B.id where A.id = 3",
 		"select S.id, S.name, B.name, B.id from S, B where B.id = 2",
 		"select S.id, S.name, B.name, B.id from S left join B on S.id > B.id",
 		"select B.name, B.id from S left join B on B.id = S.id and S.name = 'a'",
@@ -586,7 +586,7 @@ func TestMockErr(t *testing.T) {
 	querys := []string{
 		"select A.id, B.name from A right join B on A.id=B.id where A.id > 2 group by A.id",
 		"select a from A where A > 1 group by a",
-		"select /*+nested+*/ A.id, B.name, B.id from A join B on A.name=B.name where A.id = 2 and B.id = 1 group by A.id limit 1",
+		"select A.id, B.name, B.id from A join B on A.id+B.id=3 where A.id = 2 and B.id = 1 group by A.id limit 1",
 	}
 
 	for _, query := range querys {

--- a/src/executor/engine/merge_engine_test.go
+++ b/src/executor/engine/merge_engine_test.go
@@ -139,7 +139,7 @@ func TestGenerateQueryErr(t *testing.T) {
 	scatter, _, cleanup := backend.MockScatter(log, 10)
 	defer cleanup()
 
-	query := "select /*+nested+*/ B.name, A.id+B.id as id from A join B on A.name=B.name where A.id = 3"
+	query := "select B.name, A.id+B.id as id from A join B on A.name=B.name where A.id = 3"
 	want := "missing bind var A_id"
 
 	node, err := sqlparser.Parse(query)

--- a/src/planner/builder/builder.go
+++ b/src/planner/builder/builder.go
@@ -72,8 +72,6 @@ func processSelect(log *xlog.Log, router *router.Router, database string, node *
 		return root, nil
 	}
 
-	root.pushMisc(node)
-
 	var groups []selectTuple
 	fields, aggTyp, err := parseSelectExprs(node.SelectExprs, root)
 	if err != nil {
@@ -105,12 +103,15 @@ func processSelect(log *xlog.Log, router *router.Router, database string, node *
 	if err = root.pushOrderBy(node); err != nil {
 		return nil, err
 	}
+
 	// Limit SubPlan.
 	if node.Limit != nil {
 		if err = root.pushLimit(node); err != nil {
 			return nil, err
 		}
 	}
+
+	root.pushMisc(node)
 	return root, nil
 }
 

--- a/src/planner/builder/builder_test.go
+++ b/src/planner/builder/builder_test.go
@@ -159,16 +159,16 @@ func TestProcessSelect(t *testing.T) {
 		},
 
 		{
-			query:   "select /*+nested+*/ A.id from A join B on A.id = B.id where A.id = 1",
+			query:   "select A.id from A join B on A.id = B.id and concat(A.str,B.str) = 'golang' where A.id = 1",
 			project: "id",
 			out: []xcontext.QueryTuple{
 				{
-					Query:   "select /*+nested+*/ A.id from sbtest.A6 as A where A.id = 1",
+					Query:   "select A.id, A.str from sbtest.A6 as A where A.id = 1",
 					Backend: "backend6",
 					Range:   "[512-4096)",
 				},
 				{
-					Query:   "select /*+nested+*/ 1 from sbtest.B1 as B where B.id = 1 and :A_id = B.id",
+					Query:   "select 1 from sbtest.B1 as B where B.id = 1 and concat(:A_str, B.str) = 'golang' and :A_id = B.id",
 					Backend: "backend2",
 					Range:   "[512-4096)",
 				}},
@@ -488,25 +488,26 @@ func TestSelectUnsupported(t *testing.T) {
 		"select B.* from A",
 		"select * from A where a>1 having count(a) >3",
 		"select a,b from A group by B.a",
-		"select A.id,G.a as a, concat(B.str,G.str), 1 from A,B, A as G group by a",
 		"select *,avg(a) from A",
-		"select A.id from A join B on A.id=B.id right join G on G.id=A.id and A.a>B.a",
-		"select A.id from (A,B) left join G on A.id =G.id and A.a>B.a",
-		"select A.id from A join B on A.id=B.id right join G on G.id=A.id where concat(B.str,A.str) is null",
-		"select A.id from A join B on A.id >= B.id join G on G.id<=A.id where concat(B.str,A.str) is null",
-		"select A.id from A join B on A.id = B.id join G on G.id<=A.id+B.id",
-		"select A.id from A join B on A.id = B.id join G on A.id+B.id<=G.id",
-		"select A.id from G join (A,B) on A.id+B.id<=G.id",
-		"select A.id from G join (A,B) on G.id<=A.id+B.id",
 		"select sum(A.id) as tmp, B.id from A,B having tmp=1",
 		"select COALESCE(B.b, ''), IF(B.b IS NULL, FALSE, TRUE) AS spent from A left join B on A.a=B.a",
+		"select abs(B.a) AS spent,G.a from A left join B on A.a=B.a,G",
+		"select abs(B.a) AS spent,G.a from G,A left join B on A.a=B.a",
+		"select A.id from A left join B on A.id=B.id right join G on A.id = G.id where length(B.str) is null",
+		"select A.id from A left join B on A.id=B.id left join G on A.id = G.id and abs(B.a)",
+		"select A.id from A left join B on A.id=B.id join G on A.id = G.id and abs(B.a) > G.a",
+		"select A.id from A left join B on A.id=B.id join G on A.id = G.id and G.a < abs(B.a)",
+		"select A.id from A left join B on A.id=B.id left join G on A.id = G.id and G.a < abs(B.a)",
+		"select A.id from G, A left join B on A.id=B.id where G.a < abs(B.a)",
+		"select A.id from G, A left join B on A.id=B.id where abs(B.a) > G.a",
+		"select A.id from (G, A left join B on A.id=B.id),C where abs(B.a) > G.a",
+		"select A.id from C,(G, A left join B on A.id=B.id) where abs(B.a+B.b) > G.a",
 		"select A.a as b from A order by A.b",
 		"select a+1 from A order by a+1",
 		"select b as a from A group by A.a",
 		"select a+1 from A group by a+1",
 		"select count(distinct *) from A",
 		"select t1.a from G",
-		"select A.id from A join B on A.id=B.id where A.id in (1,2) or B.a=1",
 	}
 	results := []string{
 		"unsupported: subqueries.in.select",
@@ -526,25 +527,26 @@ func TestSelectUnsupported(t *testing.T) {
 		"unsupported:  unknown.table.'B'.in.field.list",
 		"unsupported: expr[count(a)].in.having.clause",
 		"unsupported: unknow.table.in.group.by.field[B.a]",
-		"unsupported: expr.'concat(B.str, G.str)'.in.cross-shard.join",
 		"unsupported: exists.aggregate.and.'*'.select.exprs",
-		"unsupported: on.clause.'A.a > B.a'.in.cross-shard.join",
-		"unsupported: expr.'A.a > B.a'.in.cross-shard.join",
-		"unsupported: expr.'concat(B.str, A.str)'.in.cross-shard.join",
-		"unsupported: clause.'concat(B.str, A.str) is null'.in.cross-shard.join",
-		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
-		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
-		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
-		"unsupported: expr.'A.id + B.id'.in.cross-shard.join",
 		"unsupported: aggregation.in.having.clause",
 		"unsupported: expr.'COALESCE(B.b, '')'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'length(B.str)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a)'.in.cross-shard.left.join",
+		"unsupported: expr.'abs(B.a + B.b)'.in.cross-shard.left.join",
 		"unsupported: orderby[A.b].should.in.select.list",
 		"unsupported: orderby:[a + 1].type.should.be.colname",
 		"unsupported: group.by.field[A.a].should.be.in.select.list",
 		"unsupported: group.by.[a + 1].type.should.be.colname",
 		"unsupported: syntax.error.at.'count(distinct *)'",
 		"unsupported: unknown.column.'t1.a'.in.exprs",
-		"unsupported: clause.'A.id in (1, 2) or B.a in (1)'.in.cross-shard.join",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
@@ -553,7 +555,7 @@ func TestSelectUnsupported(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig(), router.MockTableCConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -584,19 +586,21 @@ func TestSelectSupported(t *testing.T) {
 		"select A.id from A left join B on A.id=B.id where B.str<=>null",
 		"select A.id from A left join B on A.id=B.id where null<=>B.str",
 		"select A.id from A join B on A.id >= B.id join G on G.id<=A.id",
-		"select /*+nested+*/ A.id from A join B on A.id=B.id right join G on G.id=A.id and A.a>B.a",
-		"select /*+nested+*/ A.id from (A,B) left join G on A.id =G.id and A.a>B.a",
-		"select /*+nested+*/ A.id from A join B on A.id=B.id right join G on G.id=A.id where concat(B.str,A.str) is null",
-		"select /*+nested+*/ A.id from A join B on A.id >= B.id join G on G.id<=A.id where concat(B.str,A.str) is null",
-		"select /*+nested+*/ A.id from A join B on A.id = B.id join G on G.id<=A.id+B.id",
-		"select /*+nested+*/ A.id from A join B on A.id = B.id join G on A.id+B.id<=G.id",
-		"select /*+nested+*/ A.id from G join (A,B) on A.id+B.id<=G.id",
-		"select /*+nested+*/ A.id from G join (A,B) on G.id<=A.id+B.id",
-		"select /*+nested+*/ sum(A.id) from A join B on A.id=B.id",
-		"select /*+nested+*/ B.id,G.id,B.a from G,A,B where A.id=B.id having G.id=B.id and B.a=1 and 1=1",
+		"select A.id from A join B on A.id=B.id right join G on G.id=A.id and A.a>B.a",
+		"select A.id from (A,B) left join G on A.id =G.id and A.a>B.a",
+		"select A.id from A join B on A.id=B.id right join G on G.id=A.id where concat(B.str,A.str) is null",
+		"select A.id from A join B on A.id >= B.id join G on G.id<=A.id where concat(B.str,A.str) is null",
+		"select A.id from A join B on A.id = B.id join G on G.id<=A.id+B.id",
+		"select A.id from A join B on A.id = B.id join G on A.id+B.id<=G.id",
+		"select A.id from G join (A,B) on A.id+B.id<=G.id",
+		"select A.id from G join (A,B) on G.id<=A.id+B.id",
+		"select sum(A.id) from A join B on A.id=B.id",
+		"select B.id,G.id,B.a from G,A,B where G.a+B.a>5 having G.id=B.id and B.a=1 and 1=1",
 		"select COALESCE(A.b, ''), IF(A.b IS NULL, FALSE, TRUE) AS spent from A left join B on A.a=B.a",
 		"select COALESCE(B.b, ''), IF(B.b IS NULL, FALSE, TRUE) AS spent from A join B on A.a=B.a",
 		"select A.id from A left join B on B.id+1=A.id where B.str1+B.str2 is null",
+		"select A.id from A join B on A.id=B.id where A.id in (1,2) or B.a=1",
+		"select A.id from A join B on A.id = B.id join G on A.id+B.id<=G.id where A.str + B.str is null",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
@@ -1064,7 +1068,7 @@ func TestUnionUnsupported(t *testing.T) {
 }
 
 func TestGenerateFieldQuery(t *testing.T) {
-	query := "select /*+nested+*/ A.id+B.id from A join B on A.name=B.name"
+	query := "select A.id+B.id from A join B on A.name=B.name"
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"
 
@@ -1080,7 +1084,7 @@ func TestGenerateFieldQuery(t *testing.T) {
 	assert.Nil(t, err)
 
 	got := plan.(*JoinNode).Right.(*MergeNode).GenerateFieldQuery().Query
-	want := "select :A_id + B.id from sbtest.B1 as B where 1 != 1"
+	want := "select :A_id + B.id as `A.id + B.id` from sbtest.B1 as B where 1 != 1"
 	assert.Equal(t, want, got)
 }
 
@@ -1139,15 +1143,6 @@ func TestSelectSupportedPlanList(t *testing.T) {
 		"select A.id from A left join L on A.id=L.id where null<=>L.str",
 		"select A.id from A join L on A.id >= L.id join G on G.id<=A.id",
 		"select L.id from L join B on L.id >= B.id join G on G.id<=L.id",
-		"select /*+nested+*/ A.id from A join L on A.id=L.id right join G on G.id=L.id and A.a>L.a",
-		"select /*+nested+*/ A.id from (A,L) left join G on A.id =G.id and A.a>L.a",
-		"select /*+nested+*/ A.id from A join L on A.id=L.id right join G on G.id=A.id where concat(L.str,A.str) is null",
-		"select /*+nested+*/ A.id from A join L on A.id >= L.id join G on G.id<=A.id where concat(L.str,A.str) is null",
-		"select /*+nested+*/ A.id from A join L on A.id = L.id join G on G.id<=A.id+L.id",
-		"select /*+nested+*/ A.id from A join L on A.id = L.id join G on A.id+L.id<=G.id",
-		"select /*+nested+*/ A.id from G join (A,L) on A.id+L.id<=G.id",
-		"select /*+nested+*/ A.id from G join (A,L) on G.id<=A.id+L.id",
-		"select /*+nested+*/ sum(A.id) from A join L on A.id=L.id",
 		"select COALESCE(L.b, ''), IF(L.b IS NULL, FALSE, TRUE) AS spent from L left join B on L.a=B.a",
 		"select COALESCE(L.b, ''), IF(L.b IS NULL, FALSE, TRUE) AS spent from A join L on A.a=L.a",
 	}

--- a/src/planner/builder/common.go
+++ b/src/planner/builder/common.go
@@ -44,9 +44,9 @@ func checkTbInNode(referTables []string, tbInfos map[string]*tableInfo) bool {
 	return true
 }
 
-func isContainKey(a string, b []string) bool {
-	for _, c := range b {
-		if c == a {
+func isContainKey(a []string, b string) bool {
+	for _, c := range a {
+		if c == b {
 			return true
 		}
 	}

--- a/src/planner/builder/expr_test.go
+++ b/src/planner/builder/expr_test.go
@@ -143,48 +143,6 @@ func TestWhereFilters(t *testing.T) {
 	}
 }
 
-func TestWhereFiltersError(t *testing.T) {
-	querys := []string{
-		"select * from G,A,B where A.id=B.id and A.a + B.a > 0",
-		"select * from A join B on A.id=B.id join G on G.id=A.id where A.a + B.a > 0",
-	}
-	wants := []string{
-		"unsupported: clause.'A.a + B.a > 0'.in.cross-shard.join",
-		"unsupported: clause.'A.a + B.a > 0'.in.cross-shard.join",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		joins, filters, err := parseWhereOrJoinExprs(sel.Where.Expr, p.getReferTables())
-		assert.Nil(t, err)
-
-		err = p.pushFilter(filters)
-		assert.Nil(t, err)
-
-		p = p.pushEqualCmpr(joins)
-		p, err = p.calcRoute()
-		assert.Nil(t, err)
-
-		err = p.(*JoinNode).handleOthers()
-		got := err.Error()
-		assert.Equal(t, wants[i], got)
-	}
-}
-
 func TestCheckGroupBy(t *testing.T) {
 	querys := []string{
 		"select a,b from A group by a",
@@ -392,13 +350,9 @@ func TestSelectExprs(t *testing.T) {
 func TestSelectExprsError(t *testing.T) {
 	querys := []string{
 		"select sum(A.id) as s, G.a as a from A,G group by s",
-		"select A.id,G.a as a, concat(B.str,G.str), 1 from A,B, A as G group by a",
-		"select A.id,G.a as a, concat(A.str,B.str) from A join B on A.id=B.id join G on A.a=G.a",
 	}
 	wants := []string{
 		"unsupported: group.by.field[sum(A.id)].should.be.in.noaggregate.select.list",
-		"unsupported: expr.'concat(B.str, G.str)'.in.cross-shard.join",
-		"unsupported: expr.'concat(A.str, B.str)'.in.cross-shard.join",
 	}
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"

--- a/src/planner/builder/from_test.go
+++ b/src/planner/builder/from_test.go
@@ -118,9 +118,8 @@ func TestScanTableExprs(t *testing.T) {
 		assert.Equal(t, 0, len(m.index))
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
-		got := err.Error()
-		assert.Equal(t, "unsupported: clause.'A.b + B.b > 0'.in.cross-shard.join", got)
+		err = j.pushOthers()
+		assert.Nil(t, err)
 	}
 	// right join1.
 	{
@@ -139,7 +138,7 @@ func TestScanTableExprs(t *testing.T) {
 		assert.True(t, j.IsLeftJoin)
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
+		err = j.pushOthers()
 		assert.Nil(t, err)
 	}
 	// right join2.
@@ -171,7 +170,7 @@ func TestScanTableExprs(t *testing.T) {
 		assert.True(t, m.hasParen)
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
+		err = j.pushOthers()
 		assert.Nil(t, err)
 	}
 	// can merge shard tables.
@@ -429,9 +428,8 @@ func TestScanTableExprsList(t *testing.T) {
 		assert.Equal(t, 0, len(m.index))
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
-		got := err.Error()
-		assert.Equal(t, "unsupported: clause.'A.b + L.b > 0'.in.cross-shard.join", got)
+		err = j.pushOthers()
+		assert.Nil(t, err)
 	}
 	// right join1.
 	{
@@ -450,7 +448,7 @@ func TestScanTableExprsList(t *testing.T) {
 		assert.True(t, j.IsLeftJoin)
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
+		err = j.pushOthers()
 		assert.Nil(t, err)
 	}
 	// right join2.
@@ -481,7 +479,7 @@ func TestScanTableExprsList(t *testing.T) {
 		assert.True(t, m.hasParen)
 		assert.NotNil(t, j.otherJoinOn)
 
-		err = j.pushOtherJoin()
+		err = j.pushOthers()
 		assert.Nil(t, err)
 	}
 	// can merge shard tables.

--- a/src/planner/builder/merge_node.go
+++ b/src/planner/builder/merge_node.go
@@ -140,11 +140,6 @@ func (m *MergeNode) addHaving(expr sqlparser.Expr) {
 	m.Sel.(*sqlparser.Select).AddHaving(expr)
 }
 
-// setWhereFilter used to push the where filters.
-func (m *MergeNode) setWhereFilter(filter exprInfo) {
-	m.addWhere(filter.expr)
-}
-
 // setNoTableFilter used to push the no table filters.
 func (m *MergeNode) setNoTableFilter(exprs []sqlparser.Expr) {
 	for _, expr := range exprs {

--- a/src/planner/builder/plan_node.go
+++ b/src/planner/builder/plan_node.go
@@ -31,7 +31,6 @@ type SelectNode interface {
 	pushFilter(filters []exprInfo) error
 	pushKeyFilter(filter exprInfo, table, field string) error
 	setParent(p SelectNode)
-	setWhereFilter(filter exprInfo)
 	setNoTableFilter(exprs []sqlparser.Expr)
 	setParenthese(hasParen bool)
 	pushEqualCmpr(joins []exprInfo) SelectNode
@@ -63,4 +62,28 @@ func findLCA(h, p1, p2 SelectNode) SelectNode {
 		return pr
 	}
 	return pl
+}
+
+func findParent(tables []string, node SelectNode) SelectNode {
+	var parent SelectNode
+	for _, tb := range tables {
+		tbInfo := node.getReferTables()[tb]
+		if parent == nil {
+			parent = tbInfo.parent
+			continue
+		}
+		if parent != tbInfo.parent {
+			parent = findLCA(node, parent, tbInfo.parent)
+		}
+	}
+	return parent
+}
+
+func addFilter(s SelectNode, filter exprInfo) {
+	switch node := s.(type) {
+	case *JoinNode:
+		node.otherFilter = append(node.otherFilter, filter)
+	case *MergeNode:
+		node.addWhere(filter.expr)
+	}
 }

--- a/src/planner/builder/project.go
+++ b/src/planner/builder/project.go
@@ -76,7 +76,7 @@ func parseSelectExpr(expr *sqlparser.AliasedExpr, tbInfos map[string]*tableInfo)
 				}
 			}
 
-			if isContainKey(tableName, referTables) {
+			if isContainKey(referTables, tableName) {
 				return true, nil
 			}
 			referTables = append(referTables, tableName)
@@ -214,7 +214,7 @@ func parseExpr(expr sqlparser.Expr) selectTuple {
 				tuple.field = node.Name.String()
 			}
 			tuple.info.cols = append(tuple.info.cols, node)
-			if isContainKey(tableName, tuple.info.referTables) {
+			if isContainKey(tuple.info.referTables, tableName) {
 				return true, nil
 			}
 			tuple.info.referTables = append(tuple.info.referTables, tableName)

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -189,16 +189,16 @@ func TestSelectPlan(t *testing.T) {
 	}
 }`,
 		`{
-	"RawQuery": "select /*+nested+*/ A.id from A join B on A.id = B.id where A.id = 1",
+	"RawQuery": "select A.id from A join B on A.id = B.id where A.id = 1 and concat(A.str,B.str) = 'golang'",
 	"Project": "id",
 	"Partitions": [
 		{
-			"Query": "select /*+nested+*/ A.id from sbtest.A6 as A where A.id = 1",
+			"Query": "select A.id, A.str from sbtest.A6 as A where A.id = 1",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		},
 		{
-			"Query": "select /*+nested+*/ 1 from sbtest.B1 as B where B.id = 1 and :A_id = B.id",
+			"Query": "select 1 from sbtest.B1 as B where B.id = 1 and concat(:A_str, B.str) = 'golang' and :A_id = B.id",
 			"Backend": "backend2",
 			"Range": "[512-4096)"
 		}
@@ -426,7 +426,7 @@ func TestSelectPlan(t *testing.T) {
 		"select A.id,B.id from A join B on A.id=B.id where A.id=1",
 		"select A.id from A join B where A.id=1",
 		"select A.id from A left join B on A.id=B.id and A.a=1 and B.b=2 and 1=1 where B.id=1",
-		"select /*+nested+*/ A.id from A join B on A.id = B.id where A.id = 1",
+		"select A.id from A join B on A.id = B.id where A.id = 1 and concat(A.str,B.str) = 'golang'",
 		"select A.id from A left join B on A.a+1=B.a where A.id=1",
 		"select B.id as a from B group by a",
 		"select avg(distinct id) as tmp,b,sum(id),count(id) from B group by b",


### PR DESCRIPTION
[summary]
By analyzing the filter to automatically choose appropriate join strategy, instead of use hint.
[test case]
src/executor/engine/join_engine_test.go
src/planner/builder/builder_test.go
src/planner/builder/expr_test.go
src/planner/builder/from_test.go
src/planner/select_plan_test.go
[patch codecov]
src/planner/builder 97.8%