### PR TITLE
planner: fix the error output and improve the test coverage #525

### DIFF
--- a/src/executor/engine/merge_join.go
+++ b/src/executor/engine/merge_join.go
@@ -132,7 +132,7 @@ func keysEqual(row1, row2 []sqltypes.Value, joins []builder.JoinKey) bool {
 	return true
 }
 
-// concatLeftAndRight used to concat thle left and right results, handle otherLeftJoin|rightNull|OtherFilter.
+// concatLeftAndRight used to concat the left and right results, handle otherJoinOn|rightNull|OtherFilter.
 func concatLeftAndRight(lrows, rrows [][]sqltypes.Value, node *builder.JoinNode, res *sqltypes.Result, maxrow int) error {
 	var err error
 	var mu sync.Mutex

--- a/src/planner/builder/builder_test.go
+++ b/src/planner/builder/builder_test.go
@@ -522,6 +522,8 @@ func TestSelectUnsupported(t *testing.T) {
 		"select a+1 from A group by a+1",
 		"select count(distinct *) from A",
 		"select t1.a from G",
+		"select S.id from A join B on B.id=A.id",
+		"select eeeee from A join B on B.id=A.id",
 	}
 	results := []string{
 		"unsupported: subqueries.in.select",
@@ -561,6 +563,8 @@ func TestSelectUnsupported(t *testing.T) {
 		"unsupported: group.by.[a + 1].type.should.be.colname",
 		"unsupported: syntax.error.at.'count(distinct *)'",
 		"unsupported: unknown.column.'t1.a'.in.exprs",
+		"unsupported: unknown.column.'S.id'.in.field.list",
+		"unsupported: unknown.column.'eeeee'.in.select.exprs",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))

--- a/src/planner/builder/expr.go
+++ b/src/planner/builder/expr.go
@@ -347,8 +347,8 @@ func parseHaving(exprs sqlparser.Expr, tbInfos map[string]*tableInfo, fields []s
 	return tuples, nil
 }
 
-// getTbInExpr used to get the referred tables from the expr.
-func getTbInExpr(expr sqlparser.Expr) []string {
+// getTbsInExpr used to get the referred tables from the expr.
+func getTbsInExpr(expr sqlparser.Expr) []string {
 	var referTables []string
 	sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {

--- a/src/planner/builder/join_node.go
+++ b/src/planner/builder/join_node.go
@@ -347,12 +347,12 @@ func (j *JoinNode) judgeStrategy(filters []exprInfo) {
 		}
 
 		if exp, ok := filter.expr.(*sqlparser.ComparisonExpr); ok {
-			left := findParent(getTbInExpr(exp.Left), j)
+			left := findParent(getTbsInExpr(exp.Left), j)
 			if _, ok := left.(*JoinNode); ok {
 				j.setNestLoop()
 				return
 			}
-			right := findParent(getTbInExpr(exp.Right), j)
+			right := findParent(getTbsInExpr(exp.Right), j)
 			if _, ok := right.(*JoinNode); ok {
 				j.setNestLoop()
 			}

--- a/src/planner/builder/project.go
+++ b/src/planner/builder/project.go
@@ -72,7 +72,7 @@ func parseSelectExpr(expr *sqlparser.AliasedExpr, tbInfos map[string]*tableInfo)
 				}
 			} else {
 				if _, ok := tbInfos[tableName]; !ok {
-					return false, errors.Errorf("unsupported: unknown.column.'%s'.in.field.list", field)
+					return false, errors.Errorf("unsupported: unknown.column.'%s.%s'.in.field.list", tableName, field)
 				}
 			}
 


### PR DESCRIPTION
[summary]
fix the error output and improve the test coverage
[test case]
src/planner/builder/builder_test.go
[patch codecov]
src/planner/builder/project.go 98.1%