### PR TITLE
builder: refactor PlanNode and SelectNode #480

### DIFF
--- a/src/executor/engine/merge_join.go
+++ b/src/executor/engine/merge_join.go
@@ -132,7 +132,7 @@ func keysEqual(row1, row2 []sqltypes.Value, joins []builder.JoinKey) bool {
 	return true
 }
 
-// concatLeftAndRight used to concat the left and right results, handle otherJoinOn|rightNull|OtherFilter.
+// concatLeftAndRight used to concat the left and right results, handle otherLeftJoin|rightNull|OtherFilter.
 func concatLeftAndRight(lrows, rrows [][]sqltypes.Value, node *builder.JoinNode, res *sqltypes.Result, maxrow int) error {
 	var err error
 	var mu sync.Mutex

--- a/src/planner/builder/expr_test.go
+++ b/src/planner/builder/expr_test.go
@@ -49,28 +49,6 @@ func TestGetDMLRouting(t *testing.T) {
 	}
 }
 
-func TestParserSelectExprsSubquery(t *testing.T) {
-	query := "select A.*,(select b.str from b where A.id=B.id) str from A"
-	want := "unsupported: subqueries.in.select.exprs"
-
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
-	assert.Nil(t, err)
-
-	node, err := sqlparser.Parse(query)
-	assert.Nil(t, err)
-
-	sel := node.(*sqlparser.Select)
-	p, err := scanTableExprs(log, route, database, sel.From)
-	assert.Nil(t, err)
-	_, _, err = parseSelectExprs(sel.SelectExprs, p)
-	got := err.Error()
-	assert.Equal(t, want, got)
-}
-
 func TestParserWhereOrJoinExprs(t *testing.T) {
 	querys := []string{
 		"select * from A where id=1",
@@ -128,13 +106,8 @@ func TestWhereFilters(t *testing.T) {
 		p, err := scanTableExprs(log, route, database, sel.From)
 		assert.Nil(t, err)
 
-		joins, filters, err := parseWhereOrJoinExprs(sel.Where.Expr, p.getReferTables())
+		p, err = pushFilters(p, sel.Where.Expr)
 		assert.Nil(t, err)
-
-		err = p.pushFilter(filters)
-		assert.Nil(t, err)
-
-		p = p.pushEqualCmpr(joins)
 
 		_, err = p.calcRoute()
 		assert.Nil(t, err)
@@ -143,28 +116,9 @@ func TestWhereFilters(t *testing.T) {
 	}
 }
 
-func TestCheckGroupBy(t *testing.T) {
-	querys := []string{
-		"select a,b from A group by a",
-		"select a,b from A group by a,b",
-		"select a,b,A.id from A group by id,a",
-		"select A.id as a from A group by a",
-		"select A.id+G.id as id from A,G group by id",
-		"select A.id from A group by id",
-		"select id as a from A group by id",
-		"select id as a from A group by A.id",
-	}
-	wants := []int{
-		1,
-		2,
-		0,
-		0,
-		1,
-		0,
-		0,
-		0,
-	}
-
+func TestWhereFiltersError(t *testing.T) {
+	query := "select * from A where id=0x12"
+	want := "hash.unsupported.key.type:[3]"
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"
 
@@ -174,213 +128,31 @@ func TestCheckGroupBy(t *testing.T) {
 	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
+	node, err := sqlparser.Parse(query)
+	assert.Nil(t, err)
+	sel := node.(*sqlparser.Select)
 
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
-		assert.Nil(t, err)
-		assert.Equal(t, wants[i], len(groups))
-	}
-}
-
-func TestCheckGroupByError(t *testing.T) {
-	querys := []string{
-		"select a,b from A group by B.a",
-		"select a,b from A group by 1",
-		"select a,b from A group by a,id",
-	}
-	wants := []string{
-		"unsupported: unknow.table.in.group.by.field[B.a]",
-		"unsupported: group.by.[1].type.should.be.colname",
-		"unsupported: group.by.field[id].should.be.in.select.list",
-	}
-
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	p, err := scanTableExprs(log, route, database, sel.From)
 	assert.Nil(t, err)
 
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
+	// where filter error.
+	{
+		p, err = pushFilters(p, sel.Where.Expr)
 		got := err.Error()
-		assert.Equal(t, wants[i], got)
+		assert.Equal(t, want, got)
 	}
-}
-
-func TestCheckDistinct(t *testing.T) {
-	querys := []string{
-		"select distinct A.a,A.b as c from A",
-		"select distinct A.id from A",
-		"select distinct A.a,A.b,A.c from A group by a",
+	// check shard error.
+	{
+		_, err = checkShard("B", "id", p.getReferTables(), route)
+		assert.Equal(t, "unsupported: unknown.column.'B.id'.in.field.list", err.Error())
 	}
-	wants := []int{
-		2,
-		1,
-		1,
+	// get on tableinfo.
+	{
+		getOneTableInfo(nil)
 	}
-
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferTables(), ok)
-		assert.Nil(t, err)
-		assert.Equal(t, wants[i], len(sel.GroupBy))
-	}
-}
-
-func TestCheckDistinctError(t *testing.T) {
-	querys := []string{
-		"select distinct * from A",
-		"select distinct A.a+1 as a, A.b*10 from A",
-	}
-	wants := []string{
-		"unsupported: distinct",
-		"unsupported: distinct",
-	}
-
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		_, err = checkDistinct(sel, nil, fields, route, p.getReferTables(), ok)
-		got := err.Error()
-		assert.Equal(t, wants[i], got)
-	}
-}
-
-func TestSelectExprs(t *testing.T) {
-	querys := []string{
-		"select A.id,G.a as a, concat(B.str,G.str), 1 from A,B,G group by a",
-		"select A.id, G.a as a from A,G group by a",
-		"select A.id, B.name from A join B on A.id=B.id",
-		"select A.id, B.name from A join B on A.id=B.id join G on G.a=A.a",
-		"select sum(A.id) from A join B on A.id=B.id",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for _, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
-		assert.Nil(t, err)
-
-		err = p.pushSelectExprs(fields, groups, sel, aggTyp)
-		assert.Nil(t, err)
-
-		err = p.pushOrderBy(sel)
-		assert.Nil(t, err)
-	}
-}
-
-func TestSelectExprsError(t *testing.T) {
-	querys := []string{
-		"select sum(A.id) as s, G.a as a from A,G group by s",
-	}
-	wants := []string{
-		"unsupported: group.by.field[sum(A.id)].should.be.in.noaggregate.select.list",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-
-		_, ok := p.(*MergeNode)
-		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
-		assert.Nil(t, err)
-
-		err = p.pushSelectExprs(fields, groups, sel, aggTyp)
-		got := err.Error()
-		assert.Equal(t, wants[i], got)
+	// splitAndExpression.
+	{
+		splitAndExpression(nil, nil)
 	}
 }
 
@@ -415,10 +187,7 @@ func TestParserHaving(t *testing.T) {
 		err = p.pushSelectExprs(fields, nil, sel, aggTyp)
 		assert.Nil(t, err)
 
-		havings, err := parseHaving(sel.Having.Expr, p.getReferTables(), p.getFields())
-		assert.Nil(t, err)
-
-		err = p.pushHaving(havings)
+		err = pushHavings(p, sel.Having.Expr, p.getReferTables())
 		assert.Nil(t, err)
 	}
 }
@@ -457,181 +226,8 @@ func TestParserHavingError(t *testing.T) {
 		err = p.pushSelectExprs(fields, nil, sel, aggTyp)
 		assert.Nil(t, err)
 
-		havings, err := parseHaving(sel.Having.Expr, p.getReferTables(), p.getFields())
-		if err != nil {
-			got := err.Error()
-			assert.Equal(t, wants[i], got)
-		} else {
-			err = p.pushHaving(havings)
-			got := err.Error()
-			assert.Equal(t, wants[i], got)
-		}
-	}
-}
-
-func TestPushOrderBy(t *testing.T) {
-	querys := []string{
-		"select * from A order by a",
-		"select A.a,B.b from A join B on A.id=B.id order by A.a",
-		"select A.a,B.b from A join B on A.id=B.id group by A.a",
-		"select A.a from A order by a",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for _, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-		switch p := p.(type) {
-		case *MergeNode:
-			p.fields = fields
-		case *JoinNode:
-			p.fields = fields
-		}
-
-		err = p.pushOrderBy(sel)
-		assert.Nil(t, err)
-	}
-}
-
-func TestPushOrderByError(t *testing.T) {
-	querys := []string{
-		"select a from A order by b",
-		"select A.a from A join B on A.id=B.id order by B.b",
-		"select A.a from A join B on A.id=B.id order by C.a",
-	}
-	wants := []string{
-		"unsupported: orderby[b].should.in.select.list",
-		"unsupported: orderby[B.b].should.in.select.list",
-		"unsupported: unknow.table.in.order.by.field[C.a]",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
-		assert.Nil(t, err)
-		switch p := p.(type) {
-		case *MergeNode:
-			p.fields = fields
-		case *JoinNode:
-			p.fields = fields
-		}
-
-		err = p.pushOrderBy(sel)
+		err = pushHavings(p, sel.Having.Expr, p.getReferTables())
 		got := err.Error()
 		assert.Equal(t, wants[i], got)
-	}
-}
-
-func TestPushLimit(t *testing.T) {
-	querys := []string{
-		"select * from A limit 2",
-		"select * from A limit 2,2",
-		"select A.a,B.b from A join B on A.id=B.id order by A.a limit 2",
-		"select A.a,B.b from A join B on A.id=B.id group by A.a limit 2,2",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for _, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		err = p.pushLimit(sel)
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(p.Children()))
-	}
-}
-
-func TestPushLimitError(t *testing.T) {
-	querys := []string{
-		"select * from A limit 1.3",
-		"select A.a,B.b from A join B on A.id=B.id order by A.a limit 's'",
-	}
-	wants := []string{
-		"unsupported: limit.offset.or.counts.must.be.IntVal",
-		"unsupported: limit.offset.or.counts.must.be.IntVal",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
-	assert.Nil(t, err)
-
-	for i, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-
-		err = p.pushLimit(sel)
-		got := err.Error()
-		assert.Equal(t, wants[i], got)
-	}
-}
-func TestPushMisc(t *testing.T) {
-	querys := []string{
-		"select /* comments */ *  from A for update",
-		"select /* comments */ *  from A,B where A.id=B.id and A.id>1 for update",
-	}
-	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
-	database := "sbtest"
-
-	route, cleanup := router.MockNewRouter(log)
-	defer cleanup()
-
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
-	assert.Nil(t, err)
-
-	for _, query := range querys {
-		node, err := sqlparser.Parse(query)
-		assert.Nil(t, err)
-		sel := node.(*sqlparser.Select)
-
-		p, err := scanTableExprs(log, route, database, sel.From)
-		assert.Nil(t, err)
-		p.pushMisc(sel)
 	}
 }

--- a/src/planner/builder/plan_node_test.go
+++ b/src/planner/builder/plan_node_test.go
@@ -1,0 +1,186 @@
+/*
+ * Radon
+ *
+ * Copyright 2019 The Radon Authors.
+ * Code is licensed under the GPLv3.
+ *
+ */
+
+package builder
+
+import (
+	"testing"
+
+	"router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/xlog"
+)
+
+func TestPushOrderBy(t *testing.T) {
+	querys := []string{
+		"select * from A order by a",
+		"select A.a,B.b from A join B on A.id=B.id order by A.a",
+		"select A.a,B.b from A join B on A.id=B.id group by A.a",
+		"select A.a from A order by a",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+		switch p := p.(type) {
+		case *MergeNode:
+			p.fields = fields
+		case *JoinNode:
+			p.fields = fields
+		}
+
+		err = p.pushOrderBy(sel.OrderBy)
+		assert.Nil(t, err)
+	}
+}
+
+func TestPushOrderByError(t *testing.T) {
+	querys := []string{
+		"select a from A order by b",
+		"select A.a from A join B on A.id=B.id order by B.b",
+		"select A.a from A join B on A.id=B.id order by C.a",
+	}
+	wants := []string{
+		"unsupported: orderby[b].should.in.select.list",
+		"unsupported: orderby[B.b].should.in.select.list",
+		"unsupported: unknow.table.in.order.by.field[C.a]",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+		switch p := p.(type) {
+		case *MergeNode:
+			p.fields = fields
+		case *JoinNode:
+			p.fields = fields
+		}
+
+		err = p.pushOrderBy(sel.OrderBy)
+		got := err.Error()
+		assert.Equal(t, wants[i], got)
+	}
+}
+
+func TestPushLimit(t *testing.T) {
+	querys := []string{
+		"select * from A limit 2",
+		"select * from A limit 2,2",
+		"select A.a,B.b from A join B on A.id=B.id order by A.a limit 2",
+		"select A.a,B.b from A join B on A.id=B.id group by A.a limit 2,2",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		err = p.pushLimit(sel.Limit)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(p.Children()))
+	}
+}
+
+func TestPushLimitError(t *testing.T) {
+	querys := []string{
+		"select * from A limit 1.3",
+		"select A.a,B.b from A join B on A.id=B.id order by A.a limit 's'",
+	}
+	wants := []string{
+		"unsupported: limit.offset.or.counts.must.be.IntVal",
+		"unsupported: limit.offset.or.counts.must.be.IntVal",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		err = p.pushLimit(sel.Limit)
+		got := err.Error()
+		assert.Equal(t, wants[i], got)
+	}
+}
+func TestPushMisc(t *testing.T) {
+	querys := []string{
+		"select /* comments */ *  from A for update",
+		"select /* comments */ *  from A,B where A.id=B.id and A.id>1 for update",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+		p.pushMisc(sel)
+	}
+}

--- a/src/planner/builder/project.go
+++ b/src/planner/builder/project.go
@@ -112,7 +112,7 @@ func parseSelectExpr(expr *sqlparser.AliasedExpr, tbInfos map[string]*tableInfo)
 	return &selectTuple{expr, exprInfo{expr.Expr, referTables, cols, nil}, field, alias, funcName, aggrField, distinct, isCol}, hasAggregates, nil
 }
 
-func parseSelectExprs(exprs sqlparser.SelectExprs, root SelectNode) ([]selectTuple, aggrType, error) {
+func parseSelectExprs(exprs sqlparser.SelectExprs, root PlanNode) ([]selectTuple, aggrType, error) {
 	var tuples []selectTuple
 	hasAggs := false
 	hasDist := false

--- a/src/planner/builder/project_test.go
+++ b/src/planner/builder/project_test.go
@@ -1,0 +1,303 @@
+/*
+ * Radon
+ *
+ * Copyright 2019 The Radon Authors.
+ * Code is licensed under the GPLv3.
+ *
+ */
+
+package builder
+
+import (
+	"testing"
+
+	"router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/xlog"
+)
+
+func TestParserSelectExprsSubquery(t *testing.T) {
+	query := "select A.*,(select b.str from b where A.id=B.id) str from A"
+	want := "unsupported: subqueries.in.select.exprs"
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	node, err := sqlparser.Parse(query)
+	assert.Nil(t, err)
+
+	sel := node.(*sqlparser.Select)
+	p, err := scanTableExprs(log, route, database, sel.From)
+	assert.Nil(t, err)
+	_, _, err = parseSelectExprs(sel.SelectExprs, p)
+	got := err.Error()
+	assert.Equal(t, want, got)
+}
+
+func TestGetSelectExprs(t *testing.T) {
+	querys := []string{
+		"select a,b from A",
+		"select a,b from A union select b,a from B",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		getSelectExprs(node.(sqlparser.SelectStatement))
+	}
+}
+
+func TestCheckGroupBy(t *testing.T) {
+	querys := []string{
+		"select a,b from A group by a",
+		"select a,b from A group by a,b",
+		"select a,b,A.id from A group by id,a",
+		"select A.id as a from A group by a",
+		"select A.id+G.id as id from A,G group by id",
+		"select A.id from A group by id",
+		"select id as a from A group by id",
+		"select id as a from A group by A.id",
+	}
+	wants := []int{
+		1,
+		2,
+		0,
+		0,
+		1,
+		0,
+		0,
+		0,
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
+		assert.Nil(t, err)
+		assert.Equal(t, wants[i], len(groups))
+	}
+}
+
+func TestCheckGroupByError(t *testing.T) {
+	querys := []string{
+		"select a,b from A group by B.a",
+		"select a,b from A group by 1",
+		"select a,b from A group by a,id",
+	}
+	wants := []string{
+		"unsupported: unknow.table.in.group.by.field[B.a]",
+		"unsupported: group.by.[1].type.should.be.colname",
+		"unsupported: group.by.field[id].should.be.in.select.list",
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		_, err = checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
+		got := err.Error()
+		assert.Equal(t, wants[i], got)
+	}
+}
+
+func TestCheckDistinct(t *testing.T) {
+	querys := []string{
+		"select distinct A.a,A.b as c from A",
+		"select distinct A.id from A",
+		"select distinct A.a,A.b,A.c from A group by a",
+	}
+	wants := []int{
+		2,
+		1,
+		1,
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferTables(), ok)
+		assert.Nil(t, err)
+		assert.Equal(t, wants[i], len(sel.GroupBy))
+	}
+}
+
+func TestCheckDistinctError(t *testing.T) {
+	querys := []string{
+		"select distinct * from A",
+		"select distinct A.a+1 as a, A.b*10 from A",
+	}
+	wants := []string{
+		"unsupported: distinct",
+		"unsupported: distinct",
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, _, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		_, err = checkDistinct(sel, nil, fields, route, p.getReferTables(), ok)
+		got := err.Error()
+		assert.Equal(t, wants[i], got)
+	}
+}
+
+func TestSelectExprs(t *testing.T) {
+	querys := []string{
+		"select A.id,G.a as a, concat(B.str,G.str), 1 from A,B,G group by a",
+		"select A.id, G.a as a from A,G group by a",
+		"select A.id, B.name from A join B on A.id=B.id",
+		"select A.id, B.name from A join B on A.id=B.id join G on G.a=A.a",
+		"select sum(A.id) from A join B on A.id=B.id",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
+		assert.Nil(t, err)
+
+		err = p.pushSelectExprs(fields, groups, sel, aggTyp)
+		assert.Nil(t, err)
+
+		err = p.pushOrderBy(sel.OrderBy)
+		assert.Nil(t, err)
+	}
+}
+
+func TestSelectExprsError(t *testing.T) {
+	querys := []string{
+		"select sum(A.id) as s, G.a as a from A,G group by s",
+	}
+	wants := []string{
+		"unsupported: group.by.field[sum(A.id)].should.be.in.noaggregate.select.list",
+	}
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	assert.Nil(t, err)
+
+	for i, query := range querys {
+		node, err := sqlparser.Parse(query)
+		assert.Nil(t, err)
+		sel := node.(*sqlparser.Select)
+
+		p, err := scanTableExprs(log, route, database, sel.From)
+		assert.Nil(t, err)
+
+		fields, aggTyp, err := parseSelectExprs(sel.SelectExprs, p)
+		assert.Nil(t, err)
+
+		_, ok := p.(*MergeNode)
+		groups, err := checkGroupBy(sel.GroupBy, fields, route, p.getReferTables(), ok)
+		assert.Nil(t, err)
+
+		err = p.pushSelectExprs(fields, groups, sel, aggTyp)
+		got := err.Error()
+		assert.Equal(t, wants[i], got)
+	}
+}

--- a/src/planner/builder/union_node.go
+++ b/src/planner/builder/union_node.go
@@ -15,7 +15,20 @@ import (
 	"github.com/xelabs/go-mysqlstack/xlog"
 )
 
-// UnionNode represents union plan.
+// UnionNode ...
+// eg: select a, b from t1 union select t2.a,t3.b from t2 join t3 on t2.id=t3.id;
+//             PlanNode1
+//               /  \
+//              /    \
+//        PlanNode2  PlanNode3
+// PlanNode1: UnionNode
+// PlanNode2: MergeNode
+// PlanNode3: JoinNode
+//             /  \
+//            /    \
+//      MergeNode  MergeNode
+// PlanNode2 and PlanNode3 are two independent trees, and they are also the Left
+// and Right of PlanNode1.
 type UnionNode struct {
 	log         *xlog.Log
 	Left, Right PlanNode
@@ -63,27 +76,70 @@ func (u *UnionNode) getFields() []selectTuple {
 }
 
 // pushOrderBy used to push the order by exprs.
-func (u *UnionNode) pushOrderBy(sel sqlparser.SelectStatement) error {
-	node := sel.(*sqlparser.Union)
-	if len(node.OrderBy) > 0 {
-		orderPlan := NewOrderByPlan(u.log, node.OrderBy, u.getFields(), u.referTables)
-		if err := orderPlan.Build(); err != nil {
-			return err
-		}
-		u.children = append(u.children, orderPlan)
-	}
-	return nil
+func (u *UnionNode) pushOrderBy(orderBy sqlparser.OrderBy) error {
+	orderPlan := NewOrderByPlan(u.log, orderBy, u.getFields(), u.referTables)
+	u.children = append(u.children, orderPlan)
+	return orderPlan.Build()
 }
 
 // pushLimit used to push limit.
-func (u *UnionNode) pushLimit(sel sqlparser.SelectStatement) error {
-	node := sel.(*sqlparser.Union)
-	if node.Limit != nil {
-		limitPlan := NewLimitPlan(u.log, node.Limit)
-		if err := limitPlan.Build(); err != nil {
-			return err
-		}
-		u.children = append(u.children, limitPlan)
-	}
-	return nil
+func (u *UnionNode) pushLimit(limit *sqlparser.Limit) error {
+	limitPlan := NewLimitPlan(u.log, limit)
+	u.children = append(u.children, limitPlan)
+	return limitPlan.Build()
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) calcRoute() (PlanNode, error) {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) pushFilter(filter exprInfo) error {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) pushKeyFilter(filter exprInfo, table, field string) error {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) pushSelectExpr(field selectTuple) (int, error) {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) pushHaving(having exprInfo) error {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) pushMisc(sel *sqlparser.Select) {
+	panic("unreachable")
+}
+
+// Temporarily unreachable.
+func (u *UnionNode) addNoTableFilter(exprs []sqlparser.Expr) {
+	panic("unreachable")
+}
+
+// unreachable.
+func (u *UnionNode) pushSelectExprs(fields, groups []selectTuple, sel *sqlparser.Select, aggTyp aggrType) error {
+	panic("unreachable")
+}
+
+// unreachable.
+func (u *UnionNode) setParent(p *JoinNode) {
+	panic("unreachable")
+}
+
+// unreachable.
+func (u *UnionNode) reOrder(int) {
+	panic("unreachable")
+}
+
+// Order unreachable.
+func (u *UnionNode) Order() int {
+	panic("unreachable")
 }


### PR DESCRIPTION
[summary]
Merge SelectNode to PlanNode. The functions in UnionNode will used in subquery patch.
[test case]
src/planner/builder/builder_test.go
src/planner/builder/expr_test.go
[patch codecov]
src/planner/builder 97.6%

In function `processPart`:
```
if len(part.OrderBy) > 0 && part.Limit == nil {	
	part.OrderBy = []*sqlparser.Order{}	
}
```
is delete, because the code is an optional extra, and subquery will call the function.
Some functions in UnionNode are temporarily unreachable, it will used in subquery patch. I will rewrite the code in subquery patch. And the cove coverage is temporarily decline, will improve soon.

Some testcase were rewrited, the purpose is to improve the code coverage.