### PR TITLE
planner: GetDMLRouting support in expression #535

### DIFF
--- a/src/planner/delete_plan_test.go
+++ b/src/planner/delete_plan_test.go
@@ -79,31 +79,6 @@ func TestDeletePlan(t *testing.T) {
 	"RawQuery": "delete from sbtest.A where id in (1, 2,3)",
 	"Partitions": [
 		{
-			"Query": "delete from sbtest.A1 where id in (1, 2, 3)",
-			"Backend": "backend1",
-			"Range": "[0-32)"
-		},
-		{
-			"Query": "delete from sbtest.A2 where id in (1, 2, 3)",
-			"Backend": "backend2",
-			"Range": "[32-64)"
-		},
-		{
-			"Query": "delete from sbtest.A3 where id in (1, 2, 3)",
-			"Backend": "backend3",
-			"Range": "[64-96)"
-		},
-		{
-			"Query": "delete from sbtest.A4 where id in (1, 2, 3)",
-			"Backend": "backend4",
-			"Range": "[96-256)"
-		},
-		{
-			"Query": "delete from sbtest.A5 where id in (1, 2, 3)",
-			"Backend": "backend5",
-			"Range": "[256-512)"
-		},
-		{
 			"Query": "delete from sbtest.A6 where id in (1, 2, 3)",
 			"Backend": "backend6",
 			"Range": "[512-4096)"

--- a/src/planner/update_plan_test.go
+++ b/src/planner/update_plan_test.go
@@ -43,31 +43,6 @@ func TestUpdatePlan(t *testing.T) {
 	"RawQuery": "update sbtest.A set val = 1 where id in (1, 2)",
 	"Partitions": [
 		{
-			"Query": "update sbtest.A1 set val = 1 where id in (1, 2)",
-			"Backend": "backend1",
-			"Range": "[0-32)"
-		},
-		{
-			"Query": "update sbtest.A2 set val = 1 where id in (1, 2)",
-			"Backend": "backend2",
-			"Range": "[32-64)"
-		},
-		{
-			"Query": "update sbtest.A3 set val = 1 where id in (1, 2)",
-			"Backend": "backend3",
-			"Range": "[64-96)"
-		},
-		{
-			"Query": "update sbtest.A4 set val = 1 where id in (1, 2)",
-			"Backend": "backend4",
-			"Range": "[96-256)"
-		},
-		{
-			"Query": "update sbtest.A5 set val = 1 where id in (1, 2)",
-			"Backend": "backend5",
-			"Range": "[256-512)"
-		},
-		{
 			"Query": "update sbtest.A6 set val = 1 where id in (1, 2)",
 			"Backend": "backend6",
 			"Range": "[512-4096)"


### PR DESCRIPTION
[summary]
GetDMLRouting support in expression.
[test case]
src/planner/builder/expr_test.go
src/planner/delete_plan_test.go
src/planner/update_plan_test.go
[patch codecov]
src/planner/builder/expr.go 98.9%