### PR TITLE
planner/builder: planner support from subquery #441

### DIFF
--- a/src/planner/builder/builder.go
+++ b/src/planner/builder/builder.go
@@ -173,6 +173,7 @@ func union(log *xlog.Log, router *router.Router, database string, left, right Pl
 			v.parent = lm
 			lm.referTables[k] = v
 		}
+		lm.realTables = append(lm.realTables, rm.realTables...)
 		return lm, nil
 	}
 end:

--- a/src/planner/builder/builder_test.go
+++ b/src/planner/builder/builder_test.go
@@ -525,6 +525,7 @@ func TestSelectUnsupported(t *testing.T) {
 		"select t1.a from G",
 		"select S.id from A join B on B.id=A.id",
 		"select eeeee from A join B on B.id=A.id",
+		"select t.a from A join (select a,b,sum(c) as cnt from B) t on A.a=t.a where t.cnt + t.a>1",
 	}
 	results := []string{
 		"unsupported: subqueries.in.select",
@@ -567,6 +568,7 @@ func TestSelectUnsupported(t *testing.T) {
 		"unsupported: unknown.column.'t1.a'.in.exprs",
 		"unsupported: unknown.column.'S.id'.in.field.list",
 		"unsupported: unknown.column.'eeeee'.in.select.exprs",
+		"unsupported: aggregation.field.in.subquery.is.used.in.clause",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
@@ -793,6 +795,7 @@ func TestSelectPlanGlobal(t *testing.T) {
 		"select 1, sum(a),avg(a),a,b from sbtest.G where id>1 group by a,b order by a desc limit 10 offset 100",
 		"select G.a, G.b from G join G1 on G.a = G1.a where G1.id=1",
 		"select G.a, G.b from G, G1 where G.a = G1.a and G1.id=1",
+		"select a from (select a, id from G) as t where t.a > 1",
 	}
 
 	{

--- a/src/planner/builder/expr.go
+++ b/src/planner/builder/expr.go
@@ -415,3 +415,15 @@ func replaceCol(info exprInfo, colMap map[string]selectTuple) (exprInfo, error) 
 	info.referTables = tables
 	return info, nil
 }
+
+// fetchCols used to fetch cols from the expr.
+func fetchCols(expr sqlparser.Expr) (cols []*sqlparser.ColName) {
+	sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.ColName:
+			cols = append(cols, node)
+		}
+		return true, nil
+	}, expr)
+	return
+}

--- a/src/planner/builder/from_test.go
+++ b/src/planner/builder/from_test.go
@@ -686,7 +686,6 @@ func TestScanTableExprsListErrorDebug(t *testing.T) {
 func TestScanTableExprsError(t *testing.T) {
 	querys := []string{
 		"select * from  C where C.id=1",
-		"select * from (select * from A) as D",
 		"select * from A natural join B",
 		"select * from A join B on A.id=B.id and id=1",
 		"select * from A join B on A.id=B.id and C.id=1",
@@ -702,7 +701,6 @@ func TestScanTableExprsError(t *testing.T) {
 	}
 	wants := []string{
 		"Table 'C' doesn't exist (errno 1146) (sqlstate 42S02)",
-		"unsupported: subquery.in.select",
 		"unsupported: join.type:natural join",
 		"unsupported: unknown.column.'id'.in.clause",
 		"unsupported: unknown.column.'C.id'.in.clause",
@@ -735,7 +733,6 @@ func TestScanTableExprsError(t *testing.T) {
 
 func TestScanTableExprsListError(t *testing.T) {
 	querys := []string{
-		"select * from (select * from L) as L",
 		"select * from L natural join B",
 		"select * from A join L on A.id=L.id and id=1",
 		"select * from A join L on A.id=L.id and C.id=1",
@@ -749,7 +746,6 @@ func TestScanTableExprsListError(t *testing.T) {
 		"select * from L join A as L where L.id=1",
 	}
 	wants := []string{
-		"unsupported: subquery.in.select",
 		"unsupported: join.type:natural join",
 		"unsupported: unknown.column.'id'.in.clause",
 		"unsupported: unknown.column.'C.id'.in.clause",

--- a/src/planner/builder/subquery_node.go
+++ b/src/planner/builder/subquery_node.go
@@ -1,0 +1,273 @@
+/*
+ * Radon
+ *
+ * Copyright 2019 The Radon Authors.
+ * Code is licensed under the GPLv3.
+ *
+ */
+
+package builder
+
+import (
+	"router"
+	"xcontext"
+
+	"github.com/pkg/errors"
+	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/xlog"
+)
+
+// derived record the subquery info.
+type derived struct {
+	// derived table.
+	alias *tableInfo
+	// map of derived table's cols.
+	colMap map[string]selectTuple
+	// referred tables in subquery.
+	referTables map[string]*tableInfo
+}
+
+// SubNode used to process from subquery.
+type SubNode struct {
+	log *xlog.Log
+	// PlanNode in subquery.
+	Sub PlanNode
+	// parent node in the plan tree.
+	parent *JoinNode
+	// the returned result fields.
+	fields []selectTuple
+	// the filter without tables.
+	noTableFilter []sqlparser.Expr
+	// children plans in select(such as: orderby, limit..).
+	children []ChildPlan
+	// the subquery info
+	subInfo *derived
+	// referred tables.
+	referTables map[string]*tableInfo
+	// Cols defines which columns from results used to build the return result.
+	Cols  []int `json:",omitempty"`
+	order int
+}
+
+// newSubNode used to create SubNode.
+func newSubNode(log *xlog.Log, router *router.Router, Sub PlanNode, subInfo *derived, referTables map[string]*tableInfo) *SubNode {
+	return &SubNode{
+		log:         log,
+		Sub:         Sub,
+		subInfo:     subInfo,
+		referTables: referTables,
+	}
+}
+
+// getReferTables get the referTables.
+func (s *SubNode) getReferTables() map[string]*tableInfo {
+	return s.referTables
+}
+
+// getFields get the fields.
+func (s *SubNode) getFields() []selectTuple {
+	return s.fields
+}
+
+// pushFilter used to push the filters.
+func (s *SubNode) pushFilter(filter exprInfo) error {
+	var err error
+	filter, err = replaceCol(filter, s.subInfo.colMap)
+	if err != nil {
+		return err
+	}
+
+	if len(filter.referTables) == 0 {
+		s.noTableFilter = append(s.noTableFilter, filter.expr)
+		return nil
+	}
+
+	if len(filter.vals) > 0 {
+		if _, ok := filter.expr.(*sqlparser.ComparisonExpr).Left.(*sqlparser.ColName); !ok {
+			filter.vals = nil
+		}
+	}
+	return handleFilter(filter, s.Sub)
+}
+
+// setParent set the parent node.
+func (s *SubNode) setParent(p *JoinNode) {
+	s.parent = p
+}
+
+// addNoTableFilter used to push the no table filters.
+func (s *SubNode) addNoTableFilter(exprs []sqlparser.Expr) {
+	s.noTableFilter = append(s.noTableFilter, exprs...)
+}
+
+// calcRoute used to calc the route.
+func (s *SubNode) calcRoute() (PlanNode, error) {
+	node, err := s.Sub.calcRoute()
+	if err != nil {
+		return nil, err
+	}
+
+	if m, ok := node.(*MergeNode); ok && m.routeLen == 1 {
+		m.fields = nil
+		s.subInfo.alias.parent = m
+		m.subInfos = append(m.subInfos, s.subInfo)
+		m.hasParen = false
+		m.referTables = s.referTables
+		m.Sel = &sqlparser.Select{From: sqlparser.TableExprs([]sqlparser.TableExpr{
+			&sqlparser.AliasedTableExpr{
+				Expr: &sqlparser.Subquery{Select: m.Sel},
+				As:   sqlparser.NewTableIdent(s.subInfo.alias.alias)},
+		})}
+		m.addNoTableFilter(s.noTableFilter)
+		m.parent = s.parent
+		return m, nil
+	}
+
+	s.Sub = node
+	return s, nil
+}
+
+func (s *SubNode) pushKeyFilter(filter exprInfo, table, field string) error {
+	tuple, err := getMatchedField(field, s.subInfo.colMap)
+	if err != nil {
+		return err
+	}
+	if tuple.aggrFuc != "" {
+		return errors.New("unsupported: aggregation.field.in.subquery.is.used.in.clause")
+	}
+
+	origin := *(filter.cols[0])
+	if !tuple.isCol {
+		expr := sqlparser.CloneExpr(filter.expr)
+		newInfo := exprInfo{
+			expr:        sqlparser.ReplaceExpr(expr, fetchCols(expr)[0], tuple.info.expr),
+			referTables: tuple.info.referTables,
+			cols:        tuple.info.cols,
+		}
+		if err = handleFilter(newInfo, s.Sub); err != nil {
+			return err
+		}
+	} else {
+		filter.cols[0].Name = sqlparser.NewColIdent(tuple.field)
+		filter.cols[0].Qualifier = sqlparser.TableName{Name: sqlparser.NewTableIdent(tuple.info.referTables[0])}
+		if err = s.Sub.pushKeyFilter(filter, tuple.info.referTables[0], tuple.field); err != nil {
+			return err
+		}
+	}
+	// recover the colname.
+	*(filter.cols[0]) = origin
+	return nil
+}
+
+// pushSelectExprs used to push the select fields.
+func (s *SubNode) pushSelectExprs(fields, groups []selectTuple, sel *sqlparser.Select, aggTyp aggrType) error {
+	if len(groups) > 0 || aggTyp != nullAgg {
+		aggrPlan := NewAggregatePlan(s.log, sel.SelectExprs, fields, groups, false)
+		if err := aggrPlan.Build(); err != nil {
+			return err
+		}
+		s.children = append(s.children, aggrPlan)
+		fields = aggrPlan.tuples
+	}
+
+	for _, field := range fields {
+		if _, err := s.pushSelectExpr(field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pushSelectExpr used to push the select field, called by JoinNode.pushSelectExpr.
+func (s *SubNode) pushSelectExpr(field selectTuple) (int, error) {
+	var err error
+	var newField selectTuple
+	index := -1
+	if field.isCol {
+		for i, f := range s.Sub.getFields() {
+			name := f.alias
+			if name == "" {
+				name = f.field
+			}
+			if field.field == name {
+				index = i
+			}
+		}
+		if index == -1 {
+			return -1, errors.Errorf("unsupported: unknown.column.name.'%s'", field.field)
+		}
+		if field.alias == "" || field.alias == field.field {
+			goto end
+		}
+	}
+
+	if newField, err = replaceSelect(field, s.subInfo.colMap); err != nil {
+		return index, err
+	}
+	if index, err = handleSelectExpr(newField, s.Sub); err != nil {
+		return index, err
+	}
+end:
+	s.Cols = append(s.Cols, index)
+	s.fields = append(s.fields, field)
+	return len(s.fields) - 1, nil
+}
+
+// pushHaving used to push having exprs.
+func (s *SubNode) pushHaving(filter exprInfo) error {
+	var err error
+	filter, err = replaceCol(filter, s.subInfo.colMap)
+	if err != nil {
+		return err
+	}
+
+	if len(filter.referTables) == 0 {
+		return s.Sub.pushHaving(filter)
+	}
+	return handleHaving(filter, s.Sub)
+}
+
+// pushOrderBy used to push the order by exprs.
+func (s *SubNode) pushOrderBy(orderBy sqlparser.OrderBy) error {
+	orderPlan := NewOrderByPlan(s.log, orderBy, s.fields, s.referTables)
+	s.children = append(s.children, orderPlan)
+	return orderPlan.Build()
+}
+
+// pushLimit used to push limit.
+func (s *SubNode) pushLimit(limit *sqlparser.Limit) error {
+	limitPlan := NewLimitPlan(s.log, limit)
+	s.children = append(s.children, limitPlan)
+	return limitPlan.Build()
+}
+
+// pushMisc used tp push miscelleaneous constructs.
+func (s *SubNode) pushMisc(sel *sqlparser.Select) {
+	s.Sub.pushMisc(sel)
+}
+
+// Children returns the children of the plan.
+func (s *SubNode) Children() []ChildPlan {
+	return s.children
+}
+
+// reOrder satisfies the plannode interface.
+func (s *SubNode) reOrder(order int) {
+	s.order = order + 1
+}
+
+// Order satisfies the plannode interface.
+func (s *SubNode) Order() int {
+	return s.order
+}
+
+// buildQuery used to build the QueryTuple.
+func (s *SubNode) buildQuery(root PlanNode) {
+	s.Sub.addNoTableFilter(s.noTableFilter)
+	s.Sub.buildQuery(s.Sub)
+}
+
+// GetQuery used to get the Querys.
+func (s *SubNode) GetQuery() []xcontext.QueryTuple {
+	return s.Sub.GetQuery()
+}

--- a/src/planner/builder/subquery_test.go
+++ b/src/planner/builder/subquery_test.go
@@ -1,0 +1,700 @@
+/*
+ * Radon
+ *
+ * Copyright 2018 The Radon Authors.
+ * Code is licensed under the GPLv3.
+ *
+ */
+
+package builder
+
+import (
+	"testing"
+
+	"router"
+	"xcontext"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/xlog"
+)
+
+func TestFromSubQuery(t *testing.T) {
+	tcases := []struct {
+		query string
+		out   []xcontext.QueryTuple
+	}{
+		{
+			query: "select a from (select a, id from A) as t where t.id=1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select a from (select a, id from sbtest.A6 as A where id = 1) as t",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				}},
+		},
+		{
+			query: "select a from (select a, id from A where A.id=1) as t where t.a > 1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select a from (select a, id from sbtest.A6 as A where A.id = 1) as t where t.a > 1",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				}},
+		},
+		{
+			query: "select a from (select a, id from S) as t where t.a > 1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select a from (select a, id from sbtest.S) as t where t.a > 1",
+					Backend: "backend1",
+					Range:   "",
+				}},
+		},
+		{
+			query: "select t.id from (select a, id from G) as t,A where A.id=1 and t.a>1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select t.id from (select a, id from sbtest.G) as t, sbtest.A6 as A where A.id = 1 and t.a > 1",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				}},
+		},
+		{
+			query: "select t.b from (select A.a, A.id, B.b from A join B on A.a = B.a where A.a>1) as t where t.a<5 and id=1 group by b order by b limit 2",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select A.a, A.id from sbtest.A6 as A where A.a > 1 and A.a < 5 and A.id = 1 order by A.a asc",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				},
+				{
+					Query:   "select B.b, B.a from sbtest.B0 as B where B.a > 1 order by B.a asc",
+					Backend: "backend1",
+					Range:   "[0-512)",
+				},
+				{
+					Query:   "select B.b, B.a from sbtest.B1 as B where B.a > 1 order by B.a asc",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+		{
+			query: "select t.a from (select id as tmp,a from B where B.a>1) as t join C on t.tmp = C.id where C.id=1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select t.a, t.tmp from (select id as tmp, a from sbtest.B1 as B where B.a > 1 and B.id = 1) as t order by t.tmp asc",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+				{
+					Query:   "select C.id from sbtest.C0 as C where C.id = 1 order by C.id asc",
+					Backend: "backend1",
+					Range:   "[0-512)",
+				},
+				{
+					Query:   "select C.id from sbtest.C1 as C where C.id = 1 order by C.id asc",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+		{
+			query: "select t.a from (select id as tmp,a from B where B.a>1) as t join C on t.tmp = C.a where C.a=1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select t.a from (select id as tmp, a from sbtest.B1 as B where B.a > 1) as t join sbtest.C1 as C on t.tmp = C.a where C.a = 1",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+		{
+			query: "select a from (select A.a, B.b from A join B on concat(A.str,B.str) is not null where A.id=1) t where a+b>1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select A.a, A.str from sbtest.A6 as A where A.id = 1",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				},
+				{
+					Query:   "select B.b from sbtest.B0 as B where concat(:A_str, B.str) is not null and :A_a + B.b > 1",
+					Backend: "backend1",
+					Range:   "[0-512)",
+				},
+				{
+					Query:   "select B.b from sbtest.B1 as B where concat(:A_str, B.str) is not null and :A_a + B.b > 1",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+		{
+			query: "select t.a, t.id + B.id as id from (select S.a,A.id from A,S) t join B on t.id=B.id where t.id=1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select A.id from sbtest.A6 as A where A.id = 1",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				},
+				{
+					Query:   "select S.a from sbtest.S",
+					Backend: "backend1",
+					Range:   "",
+				},
+				{
+					Query:   "select :t_id + B.id as id from sbtest.B1 as B where B.id = 1 and :t_id = B.id",
+					Backend: "backend2",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+		{
+			query: "select * from (select A.id from A) t where id=1",
+			out: []xcontext.QueryTuple{
+				{
+					Query:   "select * from (select A.id from sbtest.A6 as A where A.id = 1) as t",
+					Backend: "backend6",
+					Range:   "[512-4096)",
+				},
+			},
+		},
+	}
+	{
+		log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+		database := "sbtest"
+
+		route, cleanup := router.MockNewRouter(log)
+		defer cleanup()
+
+		err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableSConfig(), router.MockTableGConfig(), router.MockTableBConfig(), router.MockTableCConfig())
+		assert.Nil(t, err)
+		for _, tcase := range tcases {
+			node, err := sqlparser.Parse(tcase.query)
+			assert.Nil(t, err)
+
+			// plan build
+			{
+				log.Info("--select.query:%+v", tcase.query)
+				plan, err := BuildNode(log, route, database, node.(sqlparser.SelectStatement))
+				assert.Nil(t, err)
+				q := plan.GetQuery()
+				assert.Equal(t, tcase.out, q)
+				plan.Children()
+			}
+		}
+	}
+}
+
+func TestSubqueryUnsupported(t *testing.T) {
+	testcases := []struct {
+		query string
+		out   string
+	}{
+		{
+			"select a from (select a,b from A union select a,b from B)t",
+			"unsupported: unknown.select.statement",
+		},
+		{
+			"select a from (select a,a,b from A)t",
+			"unsupported: duplicate.column.name.'a'",
+		},
+		{
+			"select t.a from (select a,sum(b) as cnt from A)t join B on t.a = B.a where t.cnt>1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select t.a from (select a,sum(b) as cnt from A)t join B on t.cnt = B.a where B.a=1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select t.a from B join (select a,sum(b) as cnt from A)t on t.cnt = B.a where B.a=1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select t.a from B left join (select a,sum(b) as cnt from A)t on t.a = B.a and t.cnt=1 where B.a=1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select t.a from B join (select a,sum(b),b as cnt from A)t on t.a = B.a where B.b+t.b>1",
+			"unsupported: clause.'B.b + t.b > 1'.in.cross-shard.join",
+		},
+		{
+			"select t.a+B.a as a from B join (select a,sum(b),b as cnt from A)t on t.a = B.a",
+			"unsupported: expr.'t.a + B.a'.in.cross-shard.join",
+		},
+		{
+			"select  t.a from B join (select a,sum(b),b as cnt from A)t on t.a = B.a join G on G.a+B.a>1",
+			"unsupported: clause.'t.a = B.a'.in.cross-shard.join",
+		},
+		{
+			"select  t.a from G join (B join (select a,sum(b),b as cnt from A)t on t.a = B.a) on G.a+B.a>1",
+			"unsupported: clause.'t.a = B.a'.in.cross-shard.join",
+		},
+		{
+			"select  t.a from (select a from A where a >1 having b>1)t",
+			"unsupported: unknown.column.'b'.in.having.clause",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig(), router.MockTableCConfig())
+	assert.Nil(t, err)
+	for _, testcase := range testcases {
+		node, err := sqlparser.Parse(testcase.query)
+		assert.Nil(t, err)
+
+		// plan build
+		{
+			log.Info("--select.query:%+v", testcase.query)
+			_, err := BuildNode(log, route, database, node.(sqlparser.SelectStatement))
+			assert.Equal(t, testcase.out, err.Error())
+		}
+	}
+}
+
+func MockSubNode(p PlanNode, sel sqlparser.SelectStatement, log *xlog.Log, r *router.Router) *SubNode {
+	tn := &tableInfo{
+		database: "sbtest",
+		alias:    "t",
+		tableExpr: &sqlparser.AliasedTableExpr{
+			Expr: &sqlparser.Subquery{Select: sel},
+			As:   sqlparser.NewTableIdent("t")},
+	}
+	referTables := map[string]*tableInfo{
+		tn.alias: tn,
+	}
+
+	// store the cols, and check the col whether exists duplicate.
+	colMap := make(map[string]selectTuple)
+	for _, field := range p.getFields() {
+		name := field.alias
+		if name == "" {
+			name = field.field
+		}
+		colMap[name] = field
+	}
+
+	subInfo := &derived{tn, colMap, p.getReferTables()}
+	return newSubNode(log, r, p, subInfo, referTables)
+}
+
+func TestSubNodePushFilter(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select a from (select a, b+1 as tmp from A) t where t.tmp > 1",
+			"b + 1 > 1",
+		},
+		{
+			"select a from (select a, b+1 as tmp from A) t where t.tmp = 1",
+			"b + 1 = 1",
+		},
+		{
+			"select a from (select a, b+1 as tmp from A) t where t.a = 1",
+			"a = 1",
+		},
+		{
+			"select a from (select a, now() as time from A) t where time > '2019-11-11 00:00:00'",
+			"now() > '2019-11-11 00:00:00'",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		joins, filters, err := parseWhereOrJoinExprs(node.(*sqlparser.Select).Where.Expr, s.getReferTables())
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(joins))
+		assert.Equal(t, 1, len(filters))
+
+		err = s.pushFilter(filters[0])
+		assert.Nil(t, err)
+		buf := sqlparser.NewTrackedBuffer(nil)
+		filters[0].expr.Format(buf)
+		assert.Equal(t, testcase.want, buf.String())
+	}
+}
+
+func TestSubNodePushFilterErr(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select a from (select a, sum(b+1) as tmp from A) t where t.tmp > 1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select a from (select A.a, B.b from A join B on A.a=B.a) t where a+b>1",
+			"unsupported: where.clause.'A.a + B.b > 1'.in.cross-shard.join",
+		},
+		{
+			"select a from (select a, b+1 as tmp from A) t where t.id > 1",
+			"unsupported: unknown.column.name.'id'",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		joins, filters, err := parseWhereOrJoinExprs(node.(*sqlparser.Select).Where.Expr, s.getReferTables())
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(joins))
+		assert.Equal(t, 1, len(filters))
+
+		err = s.pushFilter(filters[0])
+		assert.NotNil(t, err)
+		got := err.Error()
+		assert.Equal(t, testcase.want, got)
+	}
+}
+
+func getExprInfo(expr sqlparser.Expr) exprInfo {
+	var filter exprInfo
+	filter.expr = expr
+	sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.ColName:
+			filter.cols = append(filter.cols, node)
+			tableName := node.Qualifier.Name.String()
+			if isContainKey(filter.referTables, tableName) {
+				return true, nil
+			}
+			filter.referTables = append(filter.referTables, tableName)
+		}
+		return true, nil
+	}, expr)
+
+	condition, ok := expr.(*sqlparser.ComparisonExpr)
+	if ok {
+		if _, lok := condition.Left.(*sqlparser.ColName); lok {
+			if condition.Operator == sqlparser.EqualStr {
+				if sqlVal, ok := condition.Right.(*sqlparser.SQLVal); ok {
+					filter.vals = append(filter.vals, sqlVal)
+				}
+			}
+		}
+	}
+	return filter
+}
+
+func TestSubNodePushKeyFilter(t *testing.T) {
+	querys := []string{
+		"select t.a from (select a, b+1 as tmp from A where A.id=1) t join B on t.tmp = B.b where B.b > 1",
+		"select t.a from (select a, b+1 as tmp from A where A.id=1) t join B on t.tmp = B.b where B.b = 1",
+		"select t.a from (select a, b as tmp from A where A.id=1) t join B on t.tmp = B.b where B.b = 1",
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, query := range querys {
+		log.Info("--select.query:%+v", query)
+		node, err := sqlparser.Parse(query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.JoinTableExpr).LeftExpr.(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		filter := getExprInfo(node.(*sqlparser.Select).Where.Expr)
+
+		err = s.pushKeyFilter(filter, "t", "tmp")
+		assert.Nil(t, err)
+	}
+}
+
+func TestSubNodePushKeyFilterErr(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select t.a from (select a, sum(b) as tmp from A where A.id=1) t join B on t.tmp = B.b where B.b > 1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select t.a from (select a, b from A where A.id=1) t join B on t.tmp = B.b where B.b > 1",
+			"unsupported: unknown.column.name.'tmp'",
+		},
+		{
+			"select t.a from (select a, id as tmp from A where A.a=1) t join B on t.tmp = B.b where B.b = 0x12",
+			"hash.unsupported.key.type:[3]",
+		},
+		{
+			"select B.a from (select A.a+S.a as tmp from A,S) t join B on t.tmp = B.b where B.b = 1",
+			"unsupported: where.clause.'A.a + S.a = 1'.in.cross-shard.join",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.JoinTableExpr).LeftExpr.(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+		if j, ok := p.(*JoinNode); ok {
+			j.Strategy = SortMerge
+		}
+
+		s := MockSubNode(p, sub, log, route)
+		filter := getExprInfo(node.(*sqlparser.Select).Where.Expr)
+
+		err = s.pushKeyFilter(filter, "t", "tmp")
+		assert.NotNil(t, err)
+		got := err.Error()
+		assert.Equal(t, testcase.want, got)
+	}
+}
+
+func TestSubNodePushSelectExprs(t *testing.T) {
+	testcases := []struct {
+		query       string
+		projects    string
+		subProjects string
+	}{
+		{
+			"select a from (select a, b+1 as tmp from A) t group by a",
+			"a",
+			"a, tmp",
+		},
+		{
+			"select sum(a) as cnt from (select a, b+1 as tmp from A) t",
+			"cnt",
+			"a, tmp, cnt",
+		},
+		{
+			"select a as num from (select a, b+1 as tmp from A) t",
+			"num",
+			"a, tmp, num",
+		},
+		{
+			"select * from (select a, b+1 as tmp from A) t group by tmp",
+			"a, tmp",
+			"a, tmp",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		fields, aggTyp, err := parseSelectExprs(node.(*sqlparser.Select).SelectExprs, s)
+		assert.Nil(t, err)
+		groups, err := checkGroupBy(node.(*sqlparser.Select).GroupBy, fields, route, s.getReferTables(), false)
+		assert.Nil(t, err)
+		err = s.pushSelectExprs(fields, groups, node.(*sqlparser.Select), aggTyp)
+		assert.Nil(t, err)
+		assert.Equal(t, testcase.projects, GetProject(s))
+		assert.Equal(t, testcase.subProjects, GetProject(p))
+	}
+}
+
+func TestSubNodePushSelectExprsErr(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select a, num + 1 from (select a,sum(a) as num, b+1 as tmp from A) t group by a",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select b from (select a, sum(a) as num, b+1 as tmp from A) t",
+			"unsupported: unknown.column.name.'b'",
+		},
+		{
+			"select a+b from (select A.a,B.b from A,B) t",
+			"unsupported: 'a + b'.expression.in.cross-shard.query",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		fields, aggTyp, err := parseSelectExprs(node.(*sqlparser.Select).SelectExprs, s)
+		assert.Nil(t, err)
+		groups, err := checkGroupBy(node.(*sqlparser.Select).GroupBy, fields, route, s.getReferTables(), false)
+		assert.Nil(t, err)
+		err = s.pushSelectExprs(fields, groups, node.(*sqlparser.Select), aggTyp)
+		assert.NotNil(t, err)
+		assert.Equal(t, testcase.want, err.Error())
+	}
+}
+
+func TestSubNodePushHaving(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select a from (select a, b+1 as tmp from A) t having t.a > 1",
+			"a > 1",
+		},
+		{
+			"select a,time from (select a, now() as time from A) t having time > '2019-11-11 00:00:00'",
+			"now() > '2019-11-11 00:00:00'",
+		},
+		{
+			"select t.a,t.b from (select a,b from A) t, B where t.a=B.a having t.a > 1",
+			"a > 1",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		s.fields, _, err = parseSelectExprs(node.(*sqlparser.Select).SelectExprs, s)
+		assert.Nil(t, err)
+		err = pushHavings(s, node.(*sqlparser.Select).Having.Expr, s.getReferTables())
+		assert.Nil(t, err)
+
+		buf := sqlparser.NewTrackedBuffer(nil)
+		node.(*sqlparser.Select).Having.Expr.Format(buf)
+		assert.Equal(t, testcase.want, buf.String())
+	}
+}
+
+func TestSubNodePushHavingErr(t *testing.T) {
+	testcases := []struct {
+		query string
+		want  string
+	}{
+		{
+			"select a from (select a, b+1 as tmp from A) t having t.tmp > 1",
+			"unsupported: unknown.column.'t.tmp'.in.having.clause",
+		},
+		{
+			"select a,tmp from (select a, sum(b+1) as tmp from A) t having t.tmp > 1",
+			"unsupported: aggregation.field.in.subquery.is.used.in.clause",
+		},
+		{
+			"select a,b from (select A.a,B.b from A,B) t having a+b > 1",
+			"unsupported: having.clause.'A.a + B.b > 1'.in.cross-shard.join",
+		},
+	}
+
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	database := "sbtest"
+
+	route, cleanup := router.MockNewRouter(log)
+	defer cleanup()
+
+	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	assert.Nil(t, err)
+
+	for _, testcase := range testcases {
+		log.Info("--select.query:%+v", testcase.query)
+		node, err := sqlparser.Parse(testcase.query)
+		sub := node.(*sqlparser.Select).From[0].(*sqlparser.AliasedTableExpr).Expr.(*sqlparser.Subquery).Select
+		assert.Nil(t, err)
+		p, err := processPart(log, route, "sbtest", sub)
+		assert.Nil(t, err)
+
+		s := MockSubNode(p, sub, log, route)
+		s.fields, _, err = parseSelectExprs(node.(*sqlparser.Select).SelectExprs, s)
+		assert.Nil(t, err)
+		err = pushHavings(s, node.(*sqlparser.Select).Having.Expr, s.getReferTables())
+		assert.NotNil(t, err)
+		assert.Equal(t, testcase.want, err.Error())
+	}
+}


### PR DESCRIPTION
#441 
[summary]
planner support from subquery, add a new type SubNode.
[test case]
src/planner/builder/builder_test.go
src/planner/builder/from_test.go
src/planner/builder/subquery_test.go
[patch codecov]
src/planner/builder 97.8%