### PR TITLE
src: check address when add backend #546

### DIFF
--- a/src/backend/scatter.go
+++ b/src/backend/scatter.go
@@ -58,6 +58,13 @@ func (scatter *Scatter) add(config *config.BackendConfig) error {
 	if _, ok := scatter.backends[config.Name]; ok {
 		return errors.Errorf("scatter.backend[%v].duplicate", config.Name)
 	}
+	// check the address in backendsConfig, fix issue#546.
+	for _, pool := range scatter.backends {
+		if pool.conf.Address == config.Address {
+			return errors.Errorf("scatter.address[%v].already.exists.in.backends", config.Address)
+		}
+	}
+
 	pool := NewPool(scatter.log, config)
 	scatter.backends[config.Name] = pool
 	monitor.BackendInc("backend")

--- a/src/backend/scatter_test.go
+++ b/src/backend/scatter_test.go
@@ -41,6 +41,13 @@ func TestScatterAddRemove(t *testing.T) {
 		assert.NotNil(t, err)
 	}
 
+	// duplicate address
+	{
+		config2 := MockBackendConfigDefault("node2", addrs[0])
+		err := scatter.Add(config2)
+		assert.NotNil(t, err)
+	}
+
 	// remove
 	{
 		err := scatter.Remove(config1)

--- a/src/ctl/v1/backend_test.go
+++ b/src/ctl/v1/backend_test.go
@@ -47,6 +47,19 @@ func TestCtlV1BackendAdd(t *testing.T) {
 		recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("POST", "http://localhost/v1/radon/backend", p))
 		recorded.CodeIs(200)
 	}
+
+	// duplicate address.
+	{
+		p := &backendParams{
+			Name:           "backend7",
+			Address:        "192.168.0.1:3306",
+			User:           "mock",
+			Password:       "pwd",
+			MaxConnections: 1024,
+		}
+		recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("POST", "http://localhost/v1/radon/backend", p))
+		recorded.CodeIs(500)
+	}
 }
 
 func TestCtlV1BackendAddError(t *testing.T) {

--- a/src/proxy/admin_attach_test.go
+++ b/src/proxy/admin_attach_test.go
@@ -218,6 +218,25 @@ func TestAttachErrorDuplicateBackend(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestAttachErrorDuplicateAddress(t *testing.T) {
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	fakedb, proxy, cleanup := MockProxy(log)
+	defer cleanup()
+	scatter := proxy.Scatter()
+	router := proxy.Router()
+	spanner := proxy.Spanner()
+	addrs := fakedb.Addrs()
+
+	handler := NewAttach(log, scatter, router, spanner)
+
+	query := fmt.Sprintf("radon attach('%s', 'mock', 'pwd')", addrs[0])
+	node, err := sqlparser.Parse(query)
+	assert.Nil(t, err)
+	attach := node.(*sqlparser.Radon)
+	_, err = handler.Attach(attach)
+	assert.NotNil(t, err)
+}
+
 func TestAttachErrorShow(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	fakedb, proxy, cleanup := MockProxy(log)


### PR DESCRIPTION
#546
[summary]
Check address when add backend, to avoid the `xid already exists` error.
[test case]
src/backend/scatter_test.go
src/ctl/v1/backend_test.go
src/proxy/admin_attach_test.go
[patch codecov]
src/backend/scatter.go 88.7%