### PR TITLE
src: audit add status parameter #548

### DIFF
--- a/src/audit/audit.go
+++ b/src/audit/audit.go
@@ -51,6 +51,7 @@ type event struct {
 	ThreadID    uint32        `json:"thread_id"`    // Thread id.
 	CommandType string        `json:"command_type"` // Type of command.
 	Argument    string        `json:"argument"`     // Full query.
+	Status      uint16        `json:"status"`       // Status of results, if 0 success, else failure.
 	QueryRows   uint64        `json:"query_rows"`   // Query rows.
 }
 
@@ -102,7 +103,7 @@ func (a *Audit) Init() error {
 }
 
 // LogReadEvent used to handle the read-only event.
-func (a *Audit) LogReadEvent(t string, user string, host string, threadID uint32, query string, affected uint64, startTime time.Time) {
+func (a *Audit) LogReadEvent(t, user, host string, threadID uint32, query string, status uint16, affected uint64, startTime time.Time) {
 	if a.conf.Mode == ALL || a.conf.Mode == READ {
 		e := &event{
 			Start:       startTime,
@@ -113,6 +114,7 @@ func (a *Audit) LogReadEvent(t string, user string, host string, threadID uint32
 			ThreadID:    threadID,
 			CommandType: t,
 			Argument:    query,
+			Status:      status,
 			QueryRows:   affected,
 		}
 		a.queue <- e
@@ -120,7 +122,7 @@ func (a *Audit) LogReadEvent(t string, user string, host string, threadID uint32
 }
 
 // LogWriteEvent used to handle the write event.
-func (a *Audit) LogWriteEvent(t string, user string, host string, threadID uint32, query string, affected uint64, startTime time.Time) {
+func (a *Audit) LogWriteEvent(t, user, host string, threadID uint32, query string, status uint16, affected uint64, startTime time.Time) {
 	if a.conf.Mode == ALL || a.conf.Mode == WRITE {
 		e := &event{
 			Start:       startTime,
@@ -131,6 +133,7 @@ func (a *Audit) LogWriteEvent(t string, user string, host string, threadID uint3
 			ThreadID:    threadID,
 			CommandType: t,
 			Argument:    query,
+			Status:      status,
 			QueryRows:   affected,
 		}
 		a.queue <- e

--- a/src/audit/audit_easyjson.go
+++ b/src/audit/audit_easyjson.go
@@ -17,7 +17,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonF2c44427EncodeAudit1(out *jwriter.Writer, in event) {
+func easyjsonF2c44427EncodeAudit(out *jwriter.Writer, in event) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -73,6 +73,12 @@ func easyjsonF2c44427EncodeAudit1(out *jwriter.Writer, in event) {
 		out.RawByte(',')
 	}
 	first = false
+	out.RawString("\"status\":")
+	out.Uint32(uint32(in.Status))
+	if !first {
+		out.RawByte(',')
+	}
+	first = false
 	out.RawString("\"query_rows\":")
 	out.Uint64(uint64(in.QueryRows))
 	out.RawByte('}')
@@ -81,6 +87,6 @@ func easyjsonF2c44427EncodeAudit1(out *jwriter.Writer, in event) {
 // MarshalJSON supports json.Marshaler interface
 func (v event) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF2c44427EncodeAudit1(&w, v)
+	easyjsonF2c44427EncodeAudit(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }

--- a/src/audit/audit_test.go
+++ b/src/audit/audit_test.go
@@ -49,9 +49,9 @@ func TestAudit(t *testing.T) {
 		threadID := uint32(i)
 		query := "select a,b,cd from table1 where a=b and c=d and e=d group by id order\n by desc"
 		if i%2 == 0 {
-			audit.LogWriteEvent(typ, user, host, threadID, query, 0, time.Now())
+			audit.LogWriteEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 		} else {
-			audit.LogReadEvent(typ, user, host, threadID, query, 0, time.Now())
+			audit.LogReadEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 		}
 	}
 }
@@ -85,9 +85,9 @@ func TestAuditMultiThread(t *testing.T) {
 				threadID := uint32(i)
 				query := "select a,b,cd from table1 where a=b and c=d and e=d group by id order\n by desc"
 				if i%2 == 0 {
-					a.LogWriteEvent(typ, user, host, threadID, query, 0, time.Now())
+					a.LogWriteEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 				} else {
-					a.LogReadEvent(typ, user, host, threadID, query, 0, time.Now())
+					a.LogReadEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 				}
 			}
 			wait.Done()
@@ -122,9 +122,9 @@ func TestPurge(t *testing.T) {
 		threadID := uint32(i)
 		query := "select a,b,cd from table1 where a=b and c=d and e=d group by id order\n by desc"
 		if i%2 == 0 {
-			audit.LogWriteEvent(typ, user, host, threadID, query, 0, time.Now())
+			audit.LogWriteEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 		} else {
-			audit.LogReadEvent(typ, user, host, threadID, query, 0, time.Now())
+			audit.LogReadEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 		}
 	}
 	// first the close the audit to stop the event writing.
@@ -170,7 +170,7 @@ func TestAuditBench(t *testing.T) {
 			host := "127.0.0.1:8899"
 			threadID := uint32(i)
 			query := "select a,b,cd from table1 where a=b and c=d and e=d group by id order\n by desc"
-			audit.LogWriteEvent(typ, user, host, threadID, query, 0, time.Now())
+			audit.LogWriteEvent(typ, user, host, threadID, query, 0, 0, time.Now())
 		}
 		took := time.Since(now)
 		fmt.Printf(" LOOP\t%v COST %v, avg:%v/s\n", N, took, (int64(N)/(took.Nanoseconds()/1e6))*1000)

--- a/src/proxy/audit.go
+++ b/src/proxy/audit.go
@@ -24,21 +24,21 @@ const (
 	W
 )
 
-func (spanner *Spanner) auditLog(session *driver.Session, m mode, typ string, query string, qr *sqltypes.Result) error {
+func (spanner *Spanner) auditLog(session *driver.Session, m mode, typ string, query string, qr *sqltypes.Result, status uint16) error {
 	adit := spanner.audit
 	user := session.User()
 	host := session.Addr()
 	connID := session.ID()
 	affected := uint64(0)
 	if qr != nil {
-		affected = uint64(len(qr.Rows))
+		affected = qr.RowsAffected
 	}
 	now := time.Now().UTC()
 	switch m {
 	case R:
-		adit.LogReadEvent(typ, user, host, connID, query, affected, now)
+		adit.LogReadEvent(typ, user, host, connID, query, status, affected, now)
 	case W:
-		adit.LogWriteEvent(typ, user, host, connID, query, affected, now)
+		adit.LogWriteEvent(typ, user, host, connID, query, status, affected, now)
 	}
 	return nil
 }


### PR DESCRIPTION
[summary]
Add status parameter to record the status of results. If 0 sucess, else failed.
[test case]
src/audit/audit_test.go
[patch codecov]
src/audit/audit.go 86.8%
src/audit/audit_easyjson.go 98.2%
src/proxy/audit.go 100%