### PR TITLE
ctl: add an api to migrate data from one backend to another #558

### DIFF
--- a/src/ctl/router.go
+++ b/src/ctl/router.go
@@ -9,7 +9,7 @@
 package ctl
 
 import (
-	"ctl/v1"
+	v1 "ctl/v1"
 
 	"github.com/ant0ine/go-json-rest/rest"
 )
@@ -44,6 +44,7 @@ func (admin *Admin) NewRouter() (rest.App, error) {
 		rest.Get("/v1/shard/balanceadvice", v1.ShardBalanceAdviceHandler(log, proxy)),
 		rest.Post("/v1/shard/shift", v1.ShardRuleShiftHandler(log, proxy)),
 		rest.Post("/v1/shard/reload", v1.ShardReLoadHandler(log, proxy)),
+		rest.Post("/v1/shard/migrate", v1.ShardMigrateHandler(log, proxy)),
 
 		// meta
 		rest.Get("/v1/meta/versions", v1.VersionzHandler(log, proxy)),


### PR DESCRIPTION
[summary]
Used to migrate data from one backend to another.
Path:   v1/shard/migrate
Method: POST
[test case]
src/ctl/v1/shard_test.go
[patch codecov]
src/ctl/v1/shard.go 90.3%

```
mysql> explain select * from t1;
+---------------------------------------------------------------------+
| EXPLAIN                                                                                                                   
+---------------------------------------------------------------------+
| {
	"RawQuery": " select * from t1",
	"Project": "*",
	"Partitions": [
		{
			"Query": "select * from zzq.t1",
			"Backend": "backend1",
			"Range": ""
		}
	]
} |
+---------------------------------------------------------------------+
1 row in set (0.00 sec)
```
migrate `t1` from `backend1` to `backend2`:
```
$ curl -i -H 'Content-Type: application/json' -X POST -d '{"from": "xxx.xxx.xxx.xxx:xxx",
"from-user":"usr","from-password":"xxxxxxx","from-table":"t1","from-database":"zzq",
"to":"xxx.xxx.xxx.xxx:xxx","to-user":"usr","to-password":"xxxxxxx","to-database":"zzq",
"to-table":"t1","cleanup":true}'  http://127.0.0.1:8080/v1/shard/migrate
HTTP/1.1 200 OK
Date: Tue, 07 Jan 2020 09:31:21 GMT
Content-Length: 0
```
```
mysql> explain select * from t1;
+---------------------------------------------------------------------+
| EXPLAIN                                                     
+---------------------------------------------------------------------+
| {
	"RawQuery": " select * from t1",
	"Project": "*",
	"Partitions": [
		{
			"Query": "select * from zzq.t1",
			"Backend": "backend2",
			"Range": ""
		}
	]
} |
+---------------------------------------------------------------------+
1 row in set (0.00 sec)
```