### PR TITLE
shift: fix the wrong way to use waitGroup in three goroutines #556

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,35 @@
 language: go
 sudo: required
+dist: xenial
 go:
   - 1.11.x
+
+before_script: 
+  - mysqld --defaults-file=.travis/my3306.cnf --initialize-insecure 
+  - mysqld --defaults-file=.travis/my3306.cnf &
+  - mysqld --defaults-file=.travis/my3307.cnf --initialize-insecure 
+  - mysqld --defaults-file=.travis/my3307.cnf &
+  - mysqld --defaults-file=.travis/my3309.cnf --initialize-insecure
+  - mysqld --defaults-file=.travis/my3309.cnf &
+  - git clone https://github.com/radondb/radon.git
+  - cd radon
+  - make
+  - mkdir -p bin/bin/radon-meta
+  - cp ../.travis/backend.json bin/bin/radon-meta/
+  - cd ./bin
+  - ./radon -c ../conf/radon.default.json &
+  - cd ../..
 
 before_install:
 
 script:
+  - mysql -uroot -P3306 -h127.0.0.1 -e 'CREATE DATABASE IF NOT EXISTS test;'
   - make build
   - make test
   - make coverage
+  # testshift is used for make test on shift. We take it out alone because it needs to build at 
+  # least three mysql instances, so we just test it on ci. Of course you can build a test env on your machine.
+  - make testshift
 
 after_success:
   # send coverage reports to Codecov

--- a/.travis/backend.json
+++ b/.travis/backend.json
@@ -1,0 +1,14 @@
+{
+	"backends": [
+		{
+			"name": "backend1",
+			"address": "127.0.0.1:3309",
+			"user": "root",
+			"password": "",
+			"database": "",
+			"charset": "utf8",
+			"max-connections": 1024,
+			"role": 0
+		}
+	]
+}

--- a/.travis/my3306.cnf
+++ b/.travis/my3306.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+port = 3306
+socket = /tmp/mysql.sock.3306
+datadir = ./data3306
+log_bin=mysql-bin
+log_bin_index=mysql-bin.index
+binlog_format=ROW
+server-id        = 12345
+
+[mysqld_safe]

--- a/.travis/my3307.cnf
+++ b/.travis/my3307.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+port = 3307
+socket = /tmp/mysql.sock.3307
+datadir = ./data3307
+log_bin=mysql-bin
+log_bin_index=mysql-bin.index
+binlog_format=ROW
+server-id        = 12346
+
+[mysqld_safe]

--- a/.travis/my3309.cnf
+++ b/.travis/my3309.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+port = 3309
+socket = /tmp/mysql.sock.3309
+datadir = ./data3309
+log_bin=mysql-bin
+log_bin_index=mysql-bin.index
+binlog_format=ROW
+server-id        = 12347
+
+[mysqld_safe]

--- a/src/vendor/github.com/radondb/shift/makefile
+++ b/src/vendor/github.com/radondb/shift/makefile
@@ -29,11 +29,12 @@ testmysql:
 	go test -v ./vendor/github.com/siddontang/go-mysql/...
 
 # code coverage
-COVPKGS =	./shift\
-			./vendor/github.com/siddontang/go-mysql/canal/...
+COVPKGS =	./shift/...\
+   			./xbase/...\
+			./vendor/github.com/siddontang/go-mysql/...
 coverage:
 	go build -v -o bin/gotestcover \
-	./vendor/github.com/pierrre/gotestcover/*.go;
-	gotestcover -coverprofile=coverage.out -v $(COVPKGS)
+	../../pierrre/gotestcover/*.go;
+	bin/gotestcover -coverprofile=coverage.out -v $(COVPKGS)
 	go tool cover -html=coverage.out
 .PHONY: build clean install fmt test coverage .go-version

--- a/src/vendor/github.com/radondb/shift/shift/shift.go
+++ b/src/vendor/github.com/radondb/shift/shift/shift.go
@@ -379,10 +379,6 @@ func (shift *Shift) behindsCheckStart() error {
 		log.Info("shift.dumping...")
 		// If some error happened during dumping, wait dump will be still set dump done.
 		<-s.canal.WaitDumpDone()
-		// Wait dump worker done.
-		log.Info("shift.wait.dumper.background.worker...")
-		shift.handler.WaitWorkerDone()
-		log.Info("shift.wait.dumper.background.worker.done...")
 		prePos := s.canal.SyncedPosition()
 
 		for range s.behindsTicker.C {

--- a/src/vendor/github.com/radondb/shift/shift/shift_test.go
+++ b/src/vendor/github.com/radondb/shift/shift/shift_test.go
@@ -1391,6 +1391,7 @@ func TestShiftParseBOM(t *testing.T) {
 	}
 }
 
+// This test is also suit for issue https://github.com/radondb/radon/issues/556
 func TestDataRaceOnCanalStatus(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	shift := NewShift(log, mockCfg)

--- a/src/vendor/github.com/radondb/shift/vendor/github.com/siddontang/go-mysql/canal/dump.go
+++ b/src/vendor/github.com/radondb/shift/vendor/github.com/siddontang/go-mysql/canal/dump.go
@@ -155,6 +155,7 @@ func (c *Canal) dump() error {
 	if err := c.dumper.DumpAndParse(h); err != nil {
 		return errors.Trace(err)
 	}
+	c.eventHandler.WaitWorkerDone()
 
 	pos := mysql.Position{Name: h.name, Pos: uint32(h.pos)}
 	c.master.Update(pos)

--- a/src/vendor/github.com/radondb/shift/vendor/github.com/siddontang/go-mysql/canal/handler.go
+++ b/src/vendor/github.com/radondb/shift/vendor/github.com/siddontang/go-mysql/canal/handler.go
@@ -19,6 +19,7 @@ type EventHandler interface {
 	OnPosSynced(pos mysql.Position, force bool) error
 	OnXA(e *XAEvent) error
 	String() string
+	WaitWorkerDone()
 }
 
 type DummyEventHandler struct {
@@ -35,6 +36,7 @@ func (h *DummyEventHandler) OnGTID(mysql.GTIDSet) error             { return nil
 func (h *DummyEventHandler) OnPosSynced(mysql.Position, bool) error { return nil }
 func (h *DummyEventHandler) OnXA(*XAEvent) error                    { return nil }
 func (h *DummyEventHandler) String() string                         { return "DummyEventHandler" }
+func (h *DummyEventHandler) WaitWorkerDone()                        {}
 
 // `SetEventHandler` registers the sync handler, you must register your
 // own handler before starting Canal.


### PR DESCRIPTION
[summary]
Now we use wg.Add(1) / wg.Done() / wg.Wait() in different goroutines,
This way of use wg is not correct and will caused DATA RACE:
goroutine1--->wg.Add(1)
goroutine2--->wg.Done()
goroutine3--->wg.Wait()
The right way to use it will be, e.g.:
goroutine1--->wg.Add(1), wg.Wait()
goroutine2--->wg.Done()

[test case]
vendor/github.com/radondb/shift/shift/shift_test.go

[patch codecov]
vendor/github.com/radondb/shift/shift	coverage: 76.1% of statements
vendor/github.com/siddontang/go-mysql/canal	coverage: 59.0% of statements