### PR TITLE
shift: fix bug for unquoted col or table #560

### DIFF
--- a/src/vendor/github.com/radondb/shift/shift/delete.go
+++ b/src/vendor/github.com/radondb/shift/shift/delete.go
@@ -39,14 +39,14 @@ func (h *EventHandler) DeleteRow(e *canal.RowsEvent) {
 			if len(pks) > 0 {
 				for _, pk := range pks {
 					v := row[pk]
-					values = append(values, fmt.Sprintf("%s=%s", e.Table.Columns[pk].Name, h.ParseValue(e, pk, v)))
+					values = append(values, fmt.Sprintf("`%s`=%s", e.Table.Columns[pk].Name, h.ParseValue(e, pk, v)))
 				}
 			} else {
 				for j, v := range row {
 					if v == nil {
 						continue
 					}
-					values = append(values, fmt.Sprintf("%s=%s", e.Table.Columns[j].Name, h.ParseValue(e, j, v)))
+					values = append(values, fmt.Sprintf("`%s`=%s", e.Table.Columns[j].Name, h.ParseValue(e, j, v)))
 				}
 			}
 

--- a/src/vendor/github.com/radondb/shift/shift/shift.go
+++ b/src/vendor/github.com/radondb/shift/shift/shift.go
@@ -257,7 +257,7 @@ func (shift *Shift) ChecksumTable() error {
 	}
 
 	checksumFunc := func(t string, Conn *client.Conn, Database string, Table string, c chan interface{}) {
-		sql := fmt.Sprintf("checksum table %s.%s", Database, Table)
+		sql := fmt.Sprintf("checksum table `%s`.`%s`", Database, Table)
 		r, err := Conn.Execute(sql)
 		if err != nil {
 			log.Error("shift.checksum.%s.table[%s.%s].error", t, Database, Table)

--- a/src/vendor/github.com/radondb/shift/shift/update.go
+++ b/src/vendor/github.com/radondb/shift/shift/update.go
@@ -46,20 +46,20 @@ func (h *EventHandler) UpdateRow(e *canal.RowsEvent) {
 			if len(pks) > 0 {
 				for _, pk := range pks {
 					v := v1Row[pk]
-					wheres = append(wheres, fmt.Sprintf("%s=%s", e.Table.Columns[pk].Name, h.ParseValue(e, pk, v)))
+					wheres = append(wheres, fmt.Sprintf("`%s`=%s", e.Table.Columns[pk].Name, h.ParseValue(e, pk, v)))
 				}
 			}
 
 			for i := range v2Row {
 				v2 := v2Row[i]
 				if v2 != nil {
-					values = append(values, fmt.Sprintf("%s=%s", e.Table.Columns[i].Name, h.ParseValue(e, i, v2)))
+					values = append(values, fmt.Sprintf("`%s`=%s", e.Table.Columns[i].Name, h.ParseValue(e, i, v2)))
 				}
 
 				if len(pks) == 0 {
 					v1 := v1Row[i]
 					if v1 != nil {
-						wheres = append(wheres, fmt.Sprintf("%s=%s", e.Table.Columns[i].Name, h.ParseValue(e, i, v1)))
+						wheres = append(wheres, fmt.Sprintf("`%s`=%s", e.Table.Columns[i].Name, h.ParseValue(e, i, v1)))
 					}
 				}
 			}


### PR DESCRIPTION
[summary]
1. db or table name may include "-", like "a-b_db" or "a-b_tbl"
2. column name may be a keyword, like "char", "key"...
They should be quoted when send delete/update sql to backend.
[test case]
vendor/github.com/radondb/shift/shift_test
[patch codecov]
vendor/github.com/radondb/shift/shift   coverage: 76.1% of statements