### PR TITLE
*: config api support modify blocks-readonly #573

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/honnef.co
 
 # visual studio code files
 .vscode
+src/radon/bin

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,14 +55,15 @@ This document describes the RadonDB REST API, which allows users to achieve most
 Path:    /v1/radon/config
 Method:  PUT
 Request: {
-			"max-connections": The maximum permitted number of simultaneous client connections,                                    [required]
-			"max-result-size": The maximum result size(in bytes) of a query,                                                       [required]
-			"max-join-rows":   The maximum number of rows that will be held in memory for join's intermediate results.             [required]
-			"ddl-timeout":     The execution timeout(in millisecond) for DDL statements,                                           [required]
-			"query-timeout":   The execution timeout(in millisecond) for DML statements,                                           [required]
-			"twopc-enable":    Enables(true or false) radon two phase commit, for distrubuted transaction,                         [required]
-			"allowip":         ["allow-ip-1", "allow-ip-2"],                                                                       [required]
-			"audit-mode":      The audit log mode, "N": disabled, "R": read enabled, "W": write enabled, "A": read/write enabled,  [required]
+			"max-connections": The maximum permitted number of simultaneous client connections,
+			"max-result-size": The maximum result size(in bytes) of a query,
+			"max-join-rows":   The maximum number of rows that will be held in memory for join's intermediate results,
+			"ddl-timeout":     The execution timeout(in millisecond) for DDL statements,
+			"query-timeout":   The execution timeout(in millisecond) for DML statements,
+			"twopc-enable":    Enables(true or false) radon two phase commit, for distrubuted transaction,
+			"allowip":         ["allow-ip-1", "allow-ip-2"],
+			"audit-mode":      The audit log mode, "N": disabled, "R": read enabled, "W": write enabled, "A": read/write enabled,
+			"blocks-readonly": The size of a block when create hash tables,
          }
          
 ```

--- a/src/ctl/v1/radon.go
+++ b/src/ctl/v1/radon.go
@@ -27,6 +27,7 @@ type radonParams struct {
 	AllowIP          []string `json:"allowip,omitempty"`
 	AuditMode        *string  `json:"audit-mode"`
 	StreamBufferSize *int     `json:"stream-buffer-size"`
+	Blocks           *int     `json:"blocks-readonly"`
 }
 
 // RadonConfigHandler impl.
@@ -71,6 +72,9 @@ func radonConfigHandler(log *xlog.Log, proxy *proxy.Proxy, w rest.ResponseWriter
 	}
 	if p.StreamBufferSize != nil {
 		proxy.SetStreamBufferSize(*p.StreamBufferSize)
+	}
+	if p.Blocks != nil {
+		proxy.SetBlocks(*p.Blocks)
 	}
 
 	// reset the allow ip table list.

--- a/src/ctl/v1/radon_test.go
+++ b/src/ctl/v1/radon_test.go
@@ -37,12 +37,15 @@ func TestCtlV1RadonConfig(t *testing.T) {
 
 		type radonParams1 struct {
 			MaxConnections   int      `json:"max-connections"`
+			MaxResultSize    int      `json:"max-result-size"`
+			MaxJoinRows      int      `json:"max-join-rows"`
 			DDLTimeout       int      `json:"ddl-timeout"`
 			QueryTimeout     int      `json:"query-timeout"`
 			TwoPCEnable      bool     `json:"twopc-enable"`
 			AllowIP          []string `json:"allowip,omitempty"`
 			AuditMode        string   `json:"audit-mode"`
 			StreamBufferSize int      `json:"stream-buffer-size"`
+			Blocks           int      `json:"blocks-readonly"`
 		}
 
 		// 200.
@@ -50,25 +53,29 @@ func TestCtlV1RadonConfig(t *testing.T) {
 			// client
 			p := &radonParams1{
 				MaxConnections:   1023,
+				MaxResultSize:    1073741823,
+				MaxJoinRows:      32767,
 				QueryTimeout:     33,
 				TwoPCEnable:      true,
 				AllowIP:          []string{"127.0.0.1", "127.0.0.2"},
 				AuditMode:        "A",
 				StreamBufferSize: 16777216,
+				Blocks:           128,
 			}
 			recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("PUT", "http://localhost/v1/radon/config", p))
 			recorded.CodeIs(200)
 
 			radonConf := proxy.Config()
 			assert.Equal(t, 1023, radonConf.Proxy.MaxConnections)
-			assert.Equal(t, 1073741824, radonConf.Proxy.MaxResultSize)
-			assert.Equal(t, 32768, radonConf.Proxy.MaxJoinRows)
+			assert.Equal(t, 1073741823, radonConf.Proxy.MaxResultSize)
+			assert.Equal(t, 32767, radonConf.Proxy.MaxJoinRows)
 			assert.Equal(t, 0, radonConf.Proxy.DDLTimeout)
 			assert.Equal(t, 33, radonConf.Proxy.QueryTimeout)
 			assert.Equal(t, true, radonConf.Proxy.TwopcEnable)
 			assert.Equal(t, []string{"127.0.0.1", "127.0.0.2"}, radonConf.Proxy.IPS)
 			assert.Equal(t, "A", radonConf.Audit.Mode)
 			assert.Equal(t, 16777216, radonConf.Proxy.StreamBufferSize)
+			assert.Equal(t, 128, radonConf.Router.Blocks)
 		}
 
 		// Unset AllowIP.
@@ -76,6 +83,8 @@ func TestCtlV1RadonConfig(t *testing.T) {
 			// client
 			p := &radonParams1{
 				MaxConnections:   1023,
+				MaxResultSize:    1073741824,
+				MaxJoinRows:      32768,
 				QueryTimeout:     33,
 				TwoPCEnable:      true,
 				AuditMode:        "A",

--- a/src/proxy/proxy.go
+++ b/src/proxy/proxy.go
@@ -293,3 +293,11 @@ func (p *Proxy) SetStreamBufferSize(streamBufferSize int) {
 	p.log.Info("proxy.SetStreamBufferSize:[%d->%d]", p.conf.Proxy.StreamBufferSize, streamBufferSize)
 	p.conf.Proxy.StreamBufferSize = streamBufferSize
 }
+
+// SetBlocks used to set router blocks.
+func (p *Proxy) SetBlocks(blocks int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.log.Info("proxy.SetBlocks:[%d->%d]", p.conf.Router.Blocks, blocks)
+	p.conf.Router.Blocks = blocks
+}

--- a/src/proxy/proxy_test.go
+++ b/src/proxy/proxy_test.go
@@ -76,6 +76,12 @@ func TestProxy1(t *testing.T) {
 		assert.Equal(t, "A", proxy.conf.Audit.Mode)
 	}
 
+	// SetBlocks.
+	{
+		proxy.SetBlocks(256)
+		assert.Equal(t, 256, proxy.conf.Router.Blocks)
+	}
+
 	// SetThrottle
 	{
 		proxy.SetThrottle(100)


### PR DESCRIPTION
[summary]
Support modify blocks-readonly by /v1/radon/config api.
[test case]
src/ctl/v1/radon_test.go
src/proxy/proxy_test.go
[patch codecov]
src/ctl/v1/radon.go 92.4%
src/proxy/proxy.go 85.5%

```
$ curl -i -H 'Content-Type: application/json' -X PUT -d '{"blocks-readonly":64}' http://127.0.0.1:8080/v1/radon/config
HTTP/1.1 200 OK
Date: Fri, 17 Jan 2020 08:08:23 GMT
Content-Length: 0
```