### PR TITLE
*: forbid some operations when radon readonly #578

### DIFF
--- a/src/ctl/v1/shard.go
+++ b/src/ctl/v1/shard.go
@@ -414,6 +414,12 @@ func shardMigrateHandler(proxy *proxy.Proxy, w rest.ResponseWriter, r *rest.Requ
 		return
 	}
 
+	if proxy.Spanner().ReadOnly() {
+		log.Error("api.v1.shard.migrate.error:The MySQL server is running with the --read-only option")
+		rest.Error(w, "The MySQL server is running with the --read-only option", http.StatusForbidden)
+		return
+	}
+
 	// check args.
 	if len(p.From) == 0 || len(p.FromUser) == 0 || len(p.FromDatabase) == 0 || len(p.FromTable) == 0 ||
 		len(p.To) == 0 || len(p.ToUser) == 0 || len(p.ToDatabase) == 0 || len(p.ToTable) == 0 {

--- a/src/ctl/v1/shard_test.go
+++ b/src/ctl/v1/shard_test.go
@@ -1473,4 +1473,15 @@ func TestCtlV1ShardMigrateErr(t *testing.T) {
 		recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("POST", "http://localhost/v1/shard/migrate", p))
 		recorded.CodeIs(204)
 	}
+
+	// Set readonly.
+	{
+		proxy.SetReadOnly(true)
+	}
+
+	// readonly forbid.
+	{
+		recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("POST", "http://localhost/v1/shard/migrate", p))
+		recorded.CodeIs(403)
+	}
 }

--- a/src/proxy/execute_test.go
+++ b/src/proxy/execute_test.go
@@ -316,6 +316,17 @@ func TestProxyExecuteReadonly(t *testing.T) {
 		got := err.Error()
 		assert.Equal(t, want, got)
 	}
+
+	// Radon Admin.
+	{
+		client, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.Nil(t, err)
+		query := "radon attach('attach1', '127.0.0.1:6000', 'root', '123456', 'xxxx')"
+		_, err = client.FetchAll(query, -1)
+		want := "The MySQL server is running with the --read-only option so it cannot execute this statement (errno 1290) (sqlstate 42000)"
+		got := err.Error()
+		assert.Equal(t, want, got)
+	}
 }
 
 func TestProxyExecuteStreamFetch(t *testing.T) {


### PR DESCRIPTION
[summary]
Part of radon admin operations and migrate api need to add restrictions when radon in readonly.
[test case]
src/ctl/v1/shard_test.go
src/proxy/execute_test.go
[patch codecov]
src/ctl/v1/shard.go 90.3%
src/proxy/query.go 88.2%