### PR TITLE
*: add /v1/shard/status api #569

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -164,12 +164,19 @@ type BackendsConfig struct {
 	Backends []*BackendConfig `json:"backends"`
 }
 
+const (
+	// MIGRATING is intermediate state of migration.
+	MIGRATING = "migrating"
+)
+
 // PartitionConfig tuple.
 type PartitionConfig struct {
 	Table     string `json:"table"`
-	Segment   string `json:"segment"`
+	Segment   string `json:"segment,omitempty"`
 	Backend   string `json:"backend"`
-	ListValue string `json:"listvalue"`
+	ListValue string `json:"listvalue,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Cleanup   string `json:"cleanup,omitempty"`
 }
 
 // AutoIncrement tuple.
@@ -180,10 +187,10 @@ type AutoIncrement struct {
 // TableConfig tuple.
 type TableConfig struct {
 	Name          string             `json:"name"`
-	Slots         int                `json:"slots-readonly"`
-	Blocks        int                `json:"blocks-readonly"`
+	Slots         int                `json:"slots-readonly,omitempty"`
+	Blocks        int                `json:"blocks-readonly,omitempty"`
 	ShardType     string             `json:"shardtype"`
-	ShardKey      string             `json:"shardkey"`
+	ShardKey      string             `json:"shardkey,omitempty"`
 	Partitions    []*PartitionConfig `json:"partitions"`
 	AutoIncrement *AutoIncrement     `json:"auto-increment,omitempty"`
 }

--- a/src/ctl/router.go
+++ b/src/ctl/router.go
@@ -45,6 +45,7 @@ func (admin *Admin) NewRouter() (rest.App, error) {
 		rest.Post("/v1/shard/shift", v1.ShardRuleShiftHandler(log, proxy)),
 		rest.Post("/v1/shard/reload", v1.ShardReLoadHandler(log, proxy)),
 		rest.Post("/v1/shard/migrate", v1.ShardMigrateHandler(log, proxy)),
+		rest.Put("/v1/shard/status", v1.ShardStatusHandler(log, proxy)),
 
 		// meta
 		rest.Get("/v1/meta/versions", v1.VersionzHandler(log, proxy)),

--- a/src/router/api.go
+++ b/src/router/api.go
@@ -12,6 +12,7 @@ import (
 	"config"
 
 	"github.com/pkg/errors"
+	"github.com/radondb/shift/shift"
 )
 
 // RDatabase tuple.
@@ -73,10 +74,6 @@ func (r *Router) PartitionRuleShift(fromBackend string, toBackend string, databa
 // 2. Change the backend.
 // 3. Write tableconfig to disk.
 func (r *Router) changeTheRuleBackend(fromBackend string, toBackend string, database string, partitionTable string) (string, error) {
-	var table string
-	var tableConfig *config.TableConfig
-	var partitionConfig *config.PartitionConfig
-
 	log := r.log
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -85,32 +82,13 @@ func (r *Router) changeTheRuleBackend(fromBackend string, toBackend string, data
 		return "", errors.Errorf("router.rule.change.from[%s].cant.equal.to[%s]", fromBackend, toBackend)
 	}
 
-	schema, ok := r.Schemas[database]
-	if !ok {
-		return "", errors.Errorf("router.rule.change.cant.found.database:%s", database)
-	}
-
 	// 1. Find the table config.
-	found := false
-	for _, v := range schema.Tables {
-		if found {
-			break
-		}
-		for _, partition := range v.TableConfig.Partitions {
-			if (partition.Backend == fromBackend) && (partition.Table == partitionTable) {
-				log.Warning("router.rule[%s:%s].change.from[%s].to[%s].found:%+v", database, partitionTable, fromBackend, toBackend, partition)
-
-				found = true
-				table = v.Name
-				tableConfig = v.TableConfig
-				partitionConfig = partition
-				break
-			}
-		}
+	v, partitionConfig, err := r.findPartitionConfig(fromBackend, database, partitionTable)
+	if err != nil {
+		return "", err
 	}
-	if !found {
-		return "", errors.Errorf("router.rule.change.cant.found.backend[%s]+table:[%s]", fromBackend, partitionTable)
-	}
+	table := v.Name
+	tableConfig := v.TableConfig
 
 	// 2. Change the backend to to-backend.
 	if tableConfig.ShardType == "GLOBAL" {
@@ -158,4 +136,123 @@ func (r *Router) ReLoad() error {
 	// ReLoad the meta from disk.
 	log.Warning("router.reload.load.meta.from.disk...")
 	return r.LoadConfig()
+}
+
+func (r *Router) findPartitionConfig(backend, database, partitionTable string) (*Table, *config.PartitionConfig, error) {
+	schema, ok := r.Schemas[database]
+	if !ok {
+		return nil, nil, errors.Errorf("router.find.partition.config.cant.found.database:%s", database)
+	}
+
+	for _, v := range schema.Tables {
+		for _, partition := range v.TableConfig.Partitions {
+			if (partition.Backend == backend) && (partition.Table == partitionTable) {
+				log.Warning("router.find.partition.config.[%s:%s].backend.[%s].find.partition:%+v", database, partitionTable, backend, partition)
+				return v, partition, nil
+			}
+		}
+	}
+	return nil, nil, errors.Errorf("router.find.table.config.cant.found.backend[%s]+table:[%s]", backend, partitionTable)
+}
+
+// PatitionStatusModify used to modify the status and cleanup in partitionconfig.
+func (r *Router) PatitionStatusModify(migrateStatus shift.Status, isCleanup bool, fromBackend, toBackend, database, partitionTable string) error {
+	log := r.log
+
+	log.Warning("router.patition.status.modify.migrateStatus[%d].cleanup[%t].from[%s].to[%s].database[%s].partitionTable[%s]",
+		migrateStatus, isCleanup, fromBackend, toBackend, database, partitionTable)
+	table, err := r.changeTheRuleStatus(migrateStatus, isCleanup, fromBackend, toBackend, database, partitionTable)
+	if err != nil {
+		log.Error("router.patition.status.modify.changeTheRuleStatus.error:%+v", err)
+		return err
+	}
+	log.Warning("router.patition.status.modify.changeTheRuleStatus.done")
+
+	log.Warning("router.patition.status.modify.RefreshTable.prepare")
+	if err := r.RefreshTable(database, table); err != nil {
+		log.Panic("router.patition.status.modify.RefreshTable.error:%+v", err)
+		return err
+	}
+	log.Warning("router.patition.status.modify.RefreshTable.done")
+	return nil
+}
+
+// migrateStatus:
+// 0. migrating.
+//  Change the status to "migrating".
+//  Change the cleanup to "toBackend".
+//
+// 1. migrate success.
+//  Change the status to "".
+//  If isCleanup is true, the data has been cleaned up in shift, just change cleanup to "",
+//  else if shard tables, the rule `backend` has been changed to `toBackend`, so we need change cleanup to `fromBackend`,
+//  else if golbal tables, we need find the `fromBackend` partitionConfig, and change the cleanup to "".
+//
+// 2. migrate failure.
+//  Change the status to "".
+//  If isCleanup is true, just change cleanup tp "",
+//  else change cleanup to `toBackend`.
+func (r *Router) changeTheRuleStatus(migrateStatus shift.Status, isCleanup bool, fromBackend, toBackend, database, partitionTable string) (string, error) {
+	var backend, status, cleanup string
+	log := r.log
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	switch migrateStatus {
+	case shift.MIGRATING:
+		backend = fromBackend
+		status = config.MIGRATING
+		cleanup = toBackend
+	case shift.SUCCESS:
+		backend = toBackend
+		status = ""
+		if !isCleanup {
+			cleanup = fromBackend
+		}
+	case shift.FAILURE:
+		backend = fromBackend
+		status = ""
+		if !isCleanup {
+			cleanup = toBackend
+		}
+	}
+
+	// 1. Find the table config.
+	v, partitionConfig, err := r.findPartitionConfig(backend, database, partitionTable)
+	if err != nil {
+		return "", err
+	}
+	table := v.Name
+	tableConfig := v.TableConfig
+	//For golbal tables, need find the `fromBackend` partitionConfig.
+	if tableConfig.ShardType == "GLOBAL" && migrateStatus == 1 {
+		for _, partition := range v.TableConfig.Partitions {
+			if (partition.Backend == fromBackend) && (partition.Table == partitionTable) {
+				partitionConfig = partition
+				cleanup = ""
+				break
+			}
+		}
+	}
+
+	// 2. Change status and cleanup.
+	originalStatus := partitionConfig.Status
+	originalCleanup := partitionConfig.Cleanup
+	partitionConfig.Status = status
+	partitionConfig.Cleanup = cleanup
+
+	// 3. Flush table config to disk.
+	if err := r.writeTableFrmData(database, table, tableConfig); err != nil {
+		// Memory config reset.
+		partitionConfig.Status = originalStatus
+		partitionConfig.Cleanup = originalCleanup
+		return "", err
+	}
+
+	// 4. Update the version.
+	if err := config.UpdateVersion(r.metadir); err != nil {
+		log.Panicf("change.the.rule.table.update.version.error:%v", err)
+		return "", err
+	}
+	return table, nil
 }

--- a/src/vendor/github.com/radondb/shift/shift/shift.go
+++ b/src/vendor/github.com/radondb/shift/shift/shift.go
@@ -27,6 +27,18 @@ const (
 	behindsDuration = 5000
 )
 
+// Status is used to identify the migration status.
+type Status int32
+
+const (
+	// MIGRATING ...
+	MIGRATING Status = iota
+	// SUCCESS ...
+	SUCCESS
+	// FAILURE ...
+	FAILURE
+)
+
 type Shift struct {
 	log           *xlog.Log
 	cfg           *Config


### PR DESCRIPTION
[summary]
Add status api to support modify partition status and cleanup.
[test case]
src/ctl/v1/shard_test.go
src/router/api_test.go
[patch codecov]
src/ctl/v1/shard.go 91.7%
src/router/api.go 93.0%

Used to record the status in shift when migrate data.