### PR TITLE
proxy: forbid radon cleanup admin when readonly #578

### DIFF
--- a/src/proxy/query.go
+++ b/src/proxy/query.go
@@ -377,7 +377,7 @@ func (spanner *Spanner) IsDDL(node sqlparser.Statement) bool {
 func (spanner *Spanner) IsAdminCmd(node sqlparser.Statement) bool {
 	if node, ok := node.(*sqlparser.Radon); ok {
 		switch node.Action {
-		case sqlparser.AttachStr, sqlparser.DetachStr, sqlparser.ReshardStr:
+		case sqlparser.AttachStr, sqlparser.DetachStr, sqlparser.ReshardStr, sqlparser.CleanupStr:
 			return true
 		}
 	}


### PR DESCRIPTION
[summary]
Part of radon admin operations api need to add restrictions when radon in readonly.
[test case]
src/proxy/admin_cleanup_test.go
[patch codecov]
src/proxy/query.go 88.2%