### PR TITLE
config: fix missing double quotes #603

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -223,7 +223,7 @@ func (c *RouterConfig) UnmarshalJSON(b []byte) error {
 type ScatterConfig struct {
 	XaCheckInterval int    `json:"xa-check-interval"`
 	XaCheckDir      string `json:"xa-check-dir"`
-	XaCheckRetrys   int    `json:"xa-check-retrys`
+	XaCheckRetrys   int    `json:"xa-check-retrys"`
 }
 
 // DefaultScatterConfig returns default ScatterConfig config.


### PR DESCRIPTION
[summary]
Add double quotes for xa-check-retrys.
[test case]
N/A
[patch codecov]
N/A