### PR TITLE
intergration: add support for record error msg when execute error cas…

### DIFF
--- a/intergration/radon-test/mtr.sh
+++ b/intergration/radon-test/mtr.sh
@@ -22,7 +22,7 @@ do
             # record every sql executed to tmp file 
             echo $sqlWithoutSemi";" >> $tmpFile
             # execute and record result to tmp file
-            mysql -uroot -P3308 -h127.0.0.1 -e "$sqlWithoutSemi" >> $tmpFile
+            mysql --line-numbers=0 -uroot -P3308 -h127.0.0.1 -e "$sqlWithoutSemi" >> $tmpFile 2>&1
         else
             echo "empty sql, skip and continue"
         fi

--- a/intergration/radon-test/r/ddl.result
+++ b/intergration/radon-test/r/ddl.result
@@ -59,4 +59,10 @@ t	CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL,\n  `b` int(11) DEFAULT NULL,\n
 drop table integrate_test.t;
 
 
+create table integrate_test.t(
+        a int,
+        b int key) ENGINE=InnoDB DEFAULT CHARSET=utf8 PARTITION BY HASH(a);
+ERROR 1105 (HY000): The unique/primary constraint should be only defined on the sharding key column[a]
+
+
 drop database integrate_test;

--- a/intergration/radon-test/r/select.result
+++ b/intergration/radon-test/r/select.result
@@ -10,6 +10,9 @@ a	c
 2	3
 0	1
 
+select c from integrate_test.t;
+ERROR 1054 (42S22): Unknown column 'c' in 'field list'
+
 drop table integrate_test.t;
 
 

--- a/intergration/radon-test/t/ddl.test
+++ b/intergration/radon-test/t/ddl.test
@@ -35,4 +35,8 @@ create FULLTEXT index c_idx on integrate_test.t(c) WITH PARSER ngram comment 'fu
 show create table integrate_test.t;
 drop table integrate_test.t;
 
+create table integrate_test.t(
+        a int,
+        b int key) ENGINE=InnoDB DEFAULT CHARSET=utf8 PARTITION BY HASH(a);
+
 drop database integrate_test;

--- a/intergration/radon-test/t/select.test
+++ b/intergration/radon-test/t/select.test
@@ -3,6 +3,7 @@ create database integrate_test DEFAULT CHARSET=utf8;
 create table integrate_test.t(a int key, b int) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 insert into integrate_test.t(a, b) values(0,1), (2,3);
 select a, b c from integrate_test.t where a in (0,1,2) order by a desc;
+select c from integrate_test.t;
 drop table integrate_test.t;
 
 drop database integrate_test;


### PR DESCRIPTION
…e #611

[summary]
Add support for recording error case in result test file, e.g.:

create table integrate_test.t(a int key, b int) ENGINE=InnoDB DEFAULT CHARSET=utf8;
select c from integrate_test.t;
ERROR 1054 (42S22): Unknown column 'c' in 'field list'

[test case]
N/A
[patch codecov]
N/A