### PR TITLE
go-mysqlstack: fix the panic close of closed channel #614

### DIFF
--- a/src/vendor/github.com/xelabs/go-mysqlstack/driver/client.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/driver/client.go
@@ -388,7 +388,6 @@ func (c *conn) Close() error {
 		select {
 		case <-ctx.Done():
 			c.Cleanup()
-			close(quitCh)
 		case <-quitCh:
 			c.Cleanup()
 		}


### PR DESCRIPTION
[summary]
Fix the panic 'close of closed channel'.
[test case]
N/A
[patch codecov]
N/A