### PR TITLE
proxy: add hint for streaming fetch #619

### DIFF
--- a/src/proxy/query_test.go
+++ b/src/proxy/query_test.go
@@ -223,6 +223,14 @@ func TestProxyQuerys(t *testing.T) {
 			_, err = client.FetchAll(query, -1)
 			assert.Nil(t, err)
 		}
+		{ // select * from t1 as ...;
+			query := "select /*+ streaming */ * from test.t1 as aliaseTable"
+			qr, err := client.FetchAll(query, -1)
+			assert.Nil(t, err)
+			want := 60510
+			got := int(qr.RowsAffected)
+			assert.Equal(t, want, got)
+		}
 		{ // select 1 from dual
 			query := "select 1 from dual"
 			qr, err := client.FetchAll(query, -1)
@@ -314,6 +322,13 @@ func TestProxyQuerys(t *testing.T) {
 			query = "set @@SESSION.radon_streaming_fetch='OFF'"
 			_, err = client.FetchAll(query, -1)
 			assert.Nil(t, err)
+		}
+		{
+			query := "select /*+ streaming */ a from test.dual"
+			_, err = client.FetchAll(query, -1)
+			want := "Table 'dual' doesn't exist (errno 1146) (sqlstate 42S02)"
+			got := err.Error()
+			assert.Equal(t, want, got)
 		}
 	}
 }


### PR DESCRIPTION
[summary]
Add hint for streaming fetch.
select /*+ streaming */
[test case]
src/proxy/query_test.go
[patch codecov]
src/proxy/query.go 88.6%