### PR TITLE
planner: InsertPlan sorts subquery by subTable in increasing order to…

### DIFF
--- a/src/planner/insert_plan.go
+++ b/src/planner/insert_plan.go
@@ -163,8 +163,16 @@ func (p *InsertPlan) Build() error {
 		val.vals = append(val.vals, row)
 	}
 
+	// sorts SQL by rewrittenTable in increasing order to avoid deadlock #605.
+	ks := []string{}
+	for k, _ := range vals {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
 	// Rebuild querys with router info.
-	for rewritten, v := range vals {
+	for _, rewritten := range ks {
+		v := vals[rewritten]
 		buf := sqlparser.NewTrackedBuffer(nil)
 		buf.Myprintf("%s %v%sinto %s.%s%v %v%v", node.Action, node.Comments, node.Ignore, database, rewritten, node.Columns, v.vals, node.OnDup)
 		tuple := xcontext.QueryTuple{

--- a/src/planner/insert_plan.go
+++ b/src/planner/insert_plan.go
@@ -198,8 +198,6 @@ func (p *InsertPlan) JSON() string {
 	}
 
 	var parts []xcontext.QueryTuple
-	// Sort.
-	sort.Sort(xcontext.QueryTuples(p.Querys))
 	parts = append(parts, p.Querys...)
 	exp := &explain{
 		RawQuery:   p.RawQuery,

--- a/src/router/mock.go
+++ b/src/router/mock.go
@@ -105,6 +105,31 @@ func MockTableMConfig() *config.TableConfig {
 	return mock
 }
 
+// MockTableDeadLockConfig config.
+func MockTableDeadLockConfig() *config.TableConfig {
+	mock := &config.TableConfig{
+		Name:       "A",
+		ShardType:  "HASH",
+		ShardKey:   "id",
+		Partitions: make([]*config.PartitionConfig, 0, 16),
+	}
+
+	S256512 := &config.PartitionConfig{
+		Table:   "A5",
+		Segment: "0-512",
+		Backend: "backend6",
+	}
+
+	S5121024 := &config.PartitionConfig{
+		Table:   "A6",
+		Segment: "512-4096",
+		Backend: "backend6",
+	}
+
+	mock.Partitions = append(mock.Partitions,S256512, S5121024)
+	return mock
+}
+
 // MockTableBConfig config.
 func MockTableBConfig() *config.TableConfig {
 	mock := &config.TableConfig{

--- a/src/router/router_test.go
+++ b/src/router/router_test.go
@@ -94,6 +94,9 @@ func TestRouterAdd(t *testing.T) {
 		want := "router.add.db[sbtest].table[A].exists"
 		got := err.Error()
 		assert.Equal(t, want, got)
+
+		err = router.addTable("sbtest", MockTableDeadLockConfig())
+		assert.NotNil(t, err)
 	}
 
 	// unsupport shardtype


### PR DESCRIPTION
… avoid deadlock #605

[summary]
    InsertPlan sorts subquery by subTable in increasing order to avoid deadlock
[test case]
    src/planner/insert_plan_test.go
[patch codecov]
    100%