### PR TITLE
*: support read-write separation #624

### DIFF
--- a/src/backend/queryz_test.go
+++ b/src/backend/queryz_test.go
@@ -25,7 +25,7 @@ func TestQueryz(t *testing.T) {
 	defer fakedb.Close()
 	addr := fakedb.Addrs()[0]
 	conf := MockBackendConfigDefault(addr, addr)
-	pool := NewPool(log, conf)
+	pool := NewPool(log, conf, addr)
 
 	querys := []string{
 		"SELECT1",

--- a/src/backend/scatter.go
+++ b/src/backend/scatter.go
@@ -32,7 +32,7 @@ type Scatter struct {
 	mu       sync.RWMutex
 	txnMgr   *TxnManager
 	metadir  string
-	backends map[string]*Pool
+	backends map[string]*Poolz
 }
 
 // NewScatter creates a new scatter.
@@ -41,7 +41,7 @@ func NewScatter(log *xlog.Log, metadir string) *Scatter {
 		log:      log,
 		txnMgr:   NewTxnManager(log),
 		metadir:  metadir,
-		backends: make(map[string]*Pool),
+		backends: make(map[string]*Poolz),
 	}
 }
 
@@ -65,8 +65,7 @@ func (scatter *Scatter) add(config *config.BackendConfig) error {
 		}
 	}
 
-	pool := NewPool(scatter.log, config)
-	scatter.backends[config.Name] = pool
+	scatter.backends[config.Name] = NewPoolz(log, config)
 	monitor.BackendInc("backend")
 	return nil
 }
@@ -116,7 +115,7 @@ func (scatter *Scatter) clear() {
 	for _, v := range scatter.backends {
 		v.Close()
 	}
-	scatter.backends = make(map[string]*Pool)
+	scatter.backends = make(map[string]*Poolz)
 }
 
 // FlushConfig used to write the backends to file.
@@ -228,15 +227,15 @@ func (scatter *Scatter) CheckBackend(backenName string) bool {
 	return false
 }
 
-// PoolClone used to copy backends to new map.
-func (scatter *Scatter) PoolClone() map[string]*Pool {
-	poolMap := make(map[string]*Pool)
+// PoolzClone used to copy backends to new map.
+func (scatter *Scatter) PoolzClone() map[string]*Poolz {
+	poolzMap := make(map[string]*Poolz)
 	scatter.mu.RLock()
 	defer scatter.mu.RUnlock()
 	for k, v := range scatter.backends {
-		poolMap[k] = v
+		poolzMap[k] = v
 	}
-	return poolMap
+	return poolzMap
 }
 
 // BackendConfigsClone used to clone all the backend configs.
@@ -252,5 +251,5 @@ func (scatter *Scatter) BackendConfigsClone() []*config.BackendConfig {
 
 // CreateTransaction used to create a transaction.
 func (scatter *Scatter) CreateTransaction() (*Txn, error) {
-	return scatter.txnMgr.CreateTxn(scatter.PoolClone())
+	return scatter.txnMgr.CreateTxn(scatter.PoolzClone())
 }

--- a/src/backend/scatter_test.go
+++ b/src/backend/scatter_test.go
@@ -157,7 +157,7 @@ func TestScatter(t *testing.T) {
 
 	// pool clone.
 	{
-		clone := scatter.PoolClone()
+		clone := scatter.PoolzClone()
 		assert.Equal(t, clone["node1"], scatter.backends["node1"])
 	}
 

--- a/src/backend/txnmgr.go
+++ b/src/backend/txnmgr.go
@@ -71,7 +71,7 @@ func (mgr *TxnManager) Remove() error {
 }
 
 // CreateTxn creates new txn.
-func (mgr *TxnManager) CreateTxn(backends map[string]*Pool) (*Txn, error) {
+func (mgr *TxnManager) CreateTxn(backends map[string]*Poolz) (*Txn, error) {
 	if len(backends) == 0 {
 		return nil, errors.New("backends.is.NULL")
 	}

--- a/src/backend/txnmgr_test.go
+++ b/src/backend/txnmgr_test.go
@@ -21,12 +21,12 @@ func TestTxnManager(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	fakedb := fakedb.New(log, 2)
 	defer fakedb.Close()
-	backends := make(map[string]*Pool)
+	backends := make(map[string]*Poolz)
 	addrs := fakedb.Addrs()
 	for _, addr := range addrs {
 		conf := MockBackendConfigDefault(addr, addr)
-		pool := NewPool(log, conf)
-		backends[addr] = pool
+		poolz := NewPoolz(log, conf)
+		backends[addr] = poolz
 	}
 	txnmgr := NewTxnManager(log)
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -28,6 +28,7 @@ type ProxyConfig struct {
 	MetaDir     string   `json:"meta-dir"`
 	Endpoint    string   `json:"endpoint"`
 	TwopcEnable bool     `json:"twopc-enable"`
+	LoadBalance int      `json:"load-balance"` // 0 -- disable balance, 1 -- enable balance to replica
 
 	MaxConnections   int    `json:"max-connections"`
 	MaxResultSize    int    `json:"max-result-size"`
@@ -49,6 +50,7 @@ func DefaultProxyConfig() *ProxyConfig {
 	return &ProxyConfig{
 		MetaDir:          "./radon-meta",
 		Endpoint:         "127.0.0.1:3308",
+		LoadBalance:      0,
 		MaxConnections:   1024,
 		MaxResultSize:    1024 * 1024 * 1024, // 1GB
 		MaxJoinRows:      32768,
@@ -151,6 +153,7 @@ func (c *MonitorConfig) UnmarshalJSON(b []byte) error {
 type BackendConfig struct {
 	Name           string `json:"name"`
 	Address        string `json:"address"`
+	Replica        string `json:"replica-address"`
 	User           string `json:"user"`
 	Password       string `json:"password"`
 	DBName         string `json:"database"`

--- a/src/ctl/v1/backend.go
+++ b/src/ctl/v1/backend.go
@@ -22,6 +22,7 @@ import (
 type backendParams struct {
 	Name           string `json:"name"`
 	Address        string `json:"address"`
+	Replica        string `json:"replica-address"`
 	User           string `json:"user"`
 	Password       string `json:"password"`
 	MaxConnections int    `json:"max-connections"`
@@ -41,7 +42,7 @@ func initBackend(proxy *proxy.Proxy, backend string, log *xlog.Log) error {
 
 	// create db from router on the new backend, make sure the db not exists, or else return err.
 	tblList := router.Tables()
-	for db, _ := range tblList {
+	for db := range tblList {
 		query := fmt.Sprintf("create database %s", db)
 		_, err := spanner.ExecuteOnThisBackend(backend, query)
 		if err != nil {
@@ -65,6 +66,7 @@ func addBackendHandler(log *xlog.Log, proxy *proxy.Proxy, w rest.ResponseWriter,
 	conf := &config.BackendConfig{
 		Name:           p.Name,
 		Address:        p.Address,
+		Replica:        p.Replica,
 		User:           p.User,
 		Password:       p.Password,
 		Charset:        "utf8",

--- a/src/ctl/v1/backend_test.go
+++ b/src/ctl/v1/backend_test.go
@@ -40,6 +40,7 @@ func TestCtlV1BackendAdd(t *testing.T) {
 		p := &backendParams{
 			Name:           "backend6",
 			Address:        "192.168.0.1:3306",
+			Replica:        "192.168.0.2:3306",
 			User:           "mock",
 			Password:       "pwd",
 			MaxConnections: 1024,

--- a/src/ctl/v1/radon.go
+++ b/src/ctl/v1/radon.go
@@ -24,6 +24,7 @@ type radonParams struct {
 	DDLTimeout       *int     `json:"ddl-timeout"`
 	QueryTimeout     *int     `json:"query-timeout"`
 	TwoPCEnable      *bool    `json:"twopc-enable"`
+	LoadBalance      *int     `json:"load-balance"`
 	AllowIP          []string `json:"allowip,omitempty"`
 	AuditMode        *string  `json:"audit-mode"`
 	StreamBufferSize *int     `json:"stream-buffer-size"`
@@ -65,6 +66,9 @@ func radonConfigHandler(log *xlog.Log, proxy *proxy.Proxy, w rest.ResponseWriter
 	}
 	if p.TwoPCEnable != nil {
 		proxy.SetTwoPC(*p.TwoPCEnable)
+	}
+	if p.LoadBalance != nil {
+		proxy.SetLoadBalance(*p.LoadBalance)
 	}
 	proxy.SetAllowIP(p.AllowIP)
 	if p.AuditMode != nil {

--- a/src/ctl/v1/radon_test.go
+++ b/src/ctl/v1/radon_test.go
@@ -42,6 +42,7 @@ func TestCtlV1RadonConfig(t *testing.T) {
 			DDLTimeout       int      `json:"ddl-timeout"`
 			QueryTimeout     int      `json:"query-timeout"`
 			TwoPCEnable      bool     `json:"twopc-enable"`
+			LoadBalance      int      `json:"load-balance"`
 			AllowIP          []string `json:"allowip,omitempty"`
 			AuditMode        string   `json:"audit-mode"`
 			StreamBufferSize int      `json:"stream-buffer-size"`
@@ -57,6 +58,7 @@ func TestCtlV1RadonConfig(t *testing.T) {
 				MaxJoinRows:      32767,
 				QueryTimeout:     33,
 				TwoPCEnable:      true,
+				LoadBalance:      1,
 				AllowIP:          []string{"127.0.0.1", "127.0.0.2"},
 				AuditMode:        "A",
 				StreamBufferSize: 16777216,
@@ -72,6 +74,7 @@ func TestCtlV1RadonConfig(t *testing.T) {
 			assert.Equal(t, 0, radonConf.Proxy.DDLTimeout)
 			assert.Equal(t, 33, radonConf.Proxy.QueryTimeout)
 			assert.Equal(t, true, radonConf.Proxy.TwopcEnable)
+			assert.Equal(t, 1, radonConf.Proxy.LoadBalance)
 			assert.Equal(t, []string{"127.0.0.1", "127.0.0.2"}, radonConf.Proxy.IPS)
 			assert.Equal(t, "A", radonConf.Audit.Mode)
 			assert.Equal(t, 16777216, radonConf.Proxy.StreamBufferSize)

--- a/src/proxy/execute.go
+++ b/src/proxy/execute.go
@@ -65,6 +65,7 @@ func (spanner *Spanner) ExecuteSingleStmtTxnTwoPC(session *driver.Session, datab
 	txn.SetTimeout(conf.Proxy.QueryTimeout)
 	txn.SetMaxResult(conf.Proxy.MaxResultSize)
 	txn.SetMaxJoinRows(conf.Proxy.MaxJoinRows)
+	txn.SetLoadBalance(conf.Proxy.LoadBalance)
 
 	// binding.
 	sessions.TxnBinding(session, txn, node, query)
@@ -141,6 +142,7 @@ func (spanner *Spanner) executeWithTimeout(session *driver.Session, database str
 	txn.SetTimeout(timeout)
 	txn.SetMaxResult(conf.Proxy.MaxResultSize)
 	txn.SetMaxJoinRows(conf.Proxy.MaxJoinRows)
+	txn.SetLoadBalance(conf.Proxy.LoadBalance)
 
 	// binding.
 	sessions.TxnBinding(session, txn, node, query)

--- a/src/proxy/multistmt_txn.go
+++ b/src/proxy/multistmt_txn.go
@@ -93,6 +93,7 @@ func (spanner *Spanner) ExecuteBegin(session *driver.Session, query string, node
 	txn.SetMaxResult(conf.Proxy.MaxResultSize)
 	txn.SetMaxJoinRows(conf.Proxy.MaxJoinRows)
 	txn.SetMultiStmtTxn()
+	txn.SetLoadBalance(conf.Proxy.LoadBalance)
 
 	sessions.MultiStmtTxnBinding(session, txn, node, query)
 	if err := txn.BeginScatter(); err != nil {

--- a/src/proxy/proxy.go
+++ b/src/proxy/proxy.go
@@ -266,6 +266,14 @@ func (p *Proxy) SetReadOnly(val bool) {
 	p.spanner.SetReadOnly(val)
 }
 
+// SetLoadBalance used to set loadbalance.
+func (p *Proxy) SetLoadBalance(val int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.log.Info("proxy.SetLoadBalance:[%v->%v]", p.conf.Proxy.LoadBalance, val)
+	p.conf.Proxy.LoadBalance = val
+}
+
 // PeerAddress returns the peer address.
 func (p *Proxy) PeerAddress() string {
 	return p.conf.Proxy.PeerAddress

--- a/src/proxy/proxy_test.go
+++ b/src/proxy/proxy_test.go
@@ -97,6 +97,14 @@ func TestProxy1(t *testing.T) {
 		assert.Equal(t, false, proxy.spanner.ReadOnly())
 	}
 
+	// SetLoadBalance
+	{
+		proxy.SetLoadBalance(1)
+		assert.Equal(t, 1, proxy.conf.Proxy.LoadBalance)
+		proxy.SetLoadBalance(0)
+		assert.Equal(t, 0, proxy.conf.Proxy.LoadBalance)
+	}
+
 	// FlushConfig.
 	{
 		err := proxy.FlushConfig()

--- a/src/proxy/show.go
+++ b/src/proxy/show.go
@@ -483,7 +483,7 @@ func (spanner *Spanner) handleShowStatus(session *driver.Session, query string, 
 		Pools []string
 	}
 	be := poolShow{}
-	poolz := scatter.PoolClone()
+	poolz := scatter.PoolzClone()
 	for _, v := range poolz {
 		be.Pools = append(be.Pools, v.JSON())
 	}


### PR DESCRIPTION
[summary]
1.config
Add 'replica-address' to backend config, identify read-only backends vip.
Add 'loadbalance' to proxy config, 0 -- disable balance, 1 -- enable balance to replica.
2.When the statement is read and not in a multi-statement transaction, the sql will sent to the 'replica-address' for execution.

[test case]
src/backend/pool_test.go
src/backend/queryz_test.go
src/backend/txn_test.go
src/backend/txnmgr_test.go
src/proxy/proxy_test.go

[patch codecov]
src/backend/mock.go 98.8%
src/backend/pool.go 90.9%
src/backend/txn.go 89.1%
src/backend/txnmgr.go 88.5%
src/proxy/proxy.go 86.0%