### PR TITLE
*: add hint for read-write separation #624

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,7 @@ Request: {
 			"allowip":         ["allow-ip-1", "allow-ip-2"],
 			"audit-mode":      The audit log mode, "N": disabled, "R": read enabled, "W": write enabled, "A": read/write enabled,
 			"blocks-readonly": The size of a block when create hash tables,
+			"load-balance":    Enables(0 or 1) load balance, for read-write separation.
          }
          
 ```
@@ -75,7 +76,7 @@ Request: {
 ```
 `Example: `
 ```
-$ curl -i -H 'Content-Type: application/json' -X PUT -d '{"max-connections":1024, "max-result-size":1073741824, "max-join-rows":32768, "ddl-timeout":3600, "query-timeout":600, "twopc-enable":true, "allowip": ["127.0.0.1", "127.0.0.2"]}' http://127.0.0.1:8080/v1/radon/config
+$ curl -i -H 'Content-Type: application/json' -X PUT -d '{"max-connections":1024, "max-result-size":1073741824, "max-join-rows":32768, "ddl-timeout":3600, "query-timeout":600, "twopc-enable":true, "load-balance" 1, "allowip": ["127.0.0.1", "127.0.0.2"]}' http://127.0.0.1:8080/v1/radon/config
 
 ---Response---
 HTTP/1.1 200 OK
@@ -419,6 +420,7 @@ Method:  POST
 Request: {
 			"name":            "The unique name of this backend",												[required]
 			"address":         "The endpoint of this backend",													[required]
+			"replica-address": "The slave node of this backend, readonly",
 			"user":            "The user(super) for radon to be able to connect to the backend MySQL server",	[required]
 			"password":        "The password of the user",														[required]
 			"max-connections": The maximum permitted number of backend connection pool,							[optional]
@@ -436,7 +438,7 @@ Request: {
 `Example: `
 
 ```
-$ curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "backend1", "address": "127.0.0.1:3306", "user": "root", "password": "318831", "max-connections":1024}' http://127.0.0.1:8080/v1/radon/backend
+$ curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "backend1", "address": "127.0.0.1:3306", "replica-address": "127.0.0.1:3306", "user": "root", "password": "318831", "max-connections":1024}' http://127.0.0.1:8080/v1/radon/backend
 
 ---Response---
 HTTP/1.1 200 OK

--- a/docs/radon_sql_support.md
+++ b/docs/radon_sql_support.md
@@ -55,6 +55,8 @@ Contents
       * [RADON CLEANUP](#radon-cleanup)
     * [Others](#others)
       * [Using AUTO_INCREMENT](#using-auto-increment)
+      * [Streaming fetch](#Streaming-fetch)
+      * [Read-write Separation](#Read-write-Separation)
 
 # Radon SQL support
 
@@ -1331,4 +1333,37 @@ mysql> SELECT * FROM animals;
 | 1553090617754346086 | ostrich |
 +---------------------+---------+
 6 rows in set (0.02 sec)
+```
+
+### Streaming fetch
+
+`Instructions`
+* When the query result set is relatively large, the result set can be fetched by streaming.
+* Method 1: Execute `set @@ SESSION.radon_streaming_fetch = 'ON'` to turn on streaming fetch. After the query is executed, `set @@ SESSION.radon_streaming_fetch = 'OFF'` to turn off streaming fetch.
+* Method 2: Add hint `/*+ streaming */` to the query statement.
+* *Doesnot support complex queries*
+
+`Example: `
+
+```
+mysql> select /*+ streaming */ * from t1;
+Empty set (0.00 sec)
+```
+
+### Read-write Separation
+
+`Instructions`
+* If `load-balance` is 1, the query can route to the `replica-address`.
+* The query must be read and not in multi-statement txn.
+* By using `/*+ loadbalance=0 */`, the query will be forced to execute on normal `address`.
+* By using `/*+ loadbalance=1 */`, the query will be forced to execute on `replica-address`.
+
+`Example: `
+
+```
+mysql> select /*+ loadbalance=0 */ * from t1;
+Empty set (0.00 sec)
+
+mysql> select /*+ loadbalance=1 */ * from t1;
+Empty set (0.00 sec)
 ```

--- a/src/backend/txn_test.go
+++ b/src/backend/txn_test.go
@@ -105,7 +105,7 @@ func TestTxnNormalExecute(t *testing.T) {
 		assert.Nil(t, err)
 		defer txn.Finish()
 
-		txn.SetLoadBalance(1)
+		txn.SetIsExecOnRep(true)
 		got, err := txn.Execute(rctx)
 		assert.Nil(t, err)
 
@@ -197,7 +197,7 @@ func TestTxnNormalExecuteWithReplica(t *testing.T) {
 		assert.Nil(t, err)
 		defer txn.Finish()
 
-		txn.SetLoadBalance(1)
+		txn.SetIsExecOnRep(true)
 		got, err := txn.Execute(rctx)
 		assert.Nil(t, err)
 
@@ -220,7 +220,7 @@ func TestTxnNormalExecuteWithReplica(t *testing.T) {
 		assert.Nil(t, err)
 		defer txn.Finish()
 
-		txn.SetLoadBalance(1)
+		txn.SetIsExecOnRep(true)
 		got, err := txn.Execute(rctx)
 		assert.Nil(t, err)
 
@@ -239,7 +239,7 @@ func TestTxnNormalExecuteWithReplica(t *testing.T) {
 		assert.Nil(t, err)
 		defer txn.Finish()
 
-		txn.SetLoadBalance(1)
+		txn.SetIsExecOnRep(true)
 		got, err := txn.Execute(rctx)
 		assert.Nil(t, err)
 
@@ -273,7 +273,7 @@ func TestTxnExecuteReplicaError(t *testing.T) {
 		assert.Nil(t, err)
 		defer txn.Finish()
 
-		txn.SetLoadBalance(1)
+		txn.SetIsExecOnRep(true)
 		_, err = txn.Execute(rctx)
 		want := "txn.can.not.get.normal.connection.by.backend[xx].from.pool"
 		got := err.Error()

--- a/src/proxy/multistmt_txn.go
+++ b/src/proxy/multistmt_txn.go
@@ -93,7 +93,7 @@ func (spanner *Spanner) ExecuteBegin(session *driver.Session, query string, node
 	txn.SetMaxResult(conf.Proxy.MaxResultSize)
 	txn.SetMaxJoinRows(conf.Proxy.MaxJoinRows)
 	txn.SetMultiStmtTxn()
-	txn.SetLoadBalance(conf.Proxy.LoadBalance)
+	txn.SetIsExecOnRep(false)
 
 	sessions.MultiStmtTxnBinding(session, txn, node, query)
 	if err := txn.BeginScatter(); err != nil {


### PR DESCRIPTION
[summary]
The query with '/\*+loadbalance=0\*/' will be forced to execute on normal, which means loadbalance'll be disabled.
[test case]
src/backend/txn_test.go
src/proxy/execute_test.go
[patch codecov]
src/backend/txn.go 88.8%
src/proxy/execute.go 87.6%