### PR TITLE
*.: fix bugs found in intergration test issue #640

### DIFF
--- a/intergration/radon-test/r/create.result
+++ b/intergration/radon-test/r/create.result
@@ -1,3 +1,5 @@
+drop database if exists integrate_test;
+
 create database integrate_test DEFAULT CHARSET=utf8;
 
 
@@ -33,7 +35,7 @@ ERROR 1075 (42000): Incorrect table definition; there can be only one auto colum
 
 
 create table not_existing_database.test (a int) partition by hash(a) DEFAULT CHARSET=utf8;
-ERROR 1046 (3D000): No database selected
+ERROR 1049 (42000): Unknown database 'not_existing_database'
 
 
 create table integrate_test.t1 (a bigint default 100 auto_increment key) DEFAULT CHARSET=utf8;
@@ -336,6 +338,37 @@ CREATE TABLE integrate_test.t1 (v varchar(65535) key) DEFAULT CHARSET=utf8;
 ERROR 1074 (42000): Column length too big for column 'v' (max = 21845); use BLOB or TEXT instead
 
 DROP TABLE IF EXISTS integrate_test.t1;
+
+
+create /*testing bad database, database not exists*/ table not_existing_database.test (a int key);
+ERROR 1049 (42000): Unknown database 'not_existing_database'
+
+create /*testing table name with char '/', currently we don`t support it*/ table integrate_test.`a/a` (a int key);
+ERROR 1105 (HY000): invalid.table.name.currently.not.support.tablename[a/a].contains.with.char:'/' or space ' '
+
+create /*testing table name with char ' ', currently we don`t support it*/ table integrate_test.`a a` (a int key);
+ERROR 1105 (HY000): invalid.table.name.currently.not.support.tablename[a a].contains.with.char:'/' or space ' '
+
+
+create /*testing invalid database name*/ database `database bad/name/db/`;
+ERROR 1105 (HY000): invalid.database.name.currently.not.support.dbname[database bad/name/db/].contains.with.char:'/' or space ' '
+
+create /*testing invalid database name with space char ' '*/ database `database bad`;
+ERROR 1105 (HY000): invalid.database.name.currently.not.support.dbname[database bad].contains.with.char:'/' or space ' '
+
+create /*testing invalid database name with '/' */ database `database/bad`;
+ERROR 1105 (HY000): invalid.database.name.currently.not.support.dbname[database/bad].contains.with.char:'/' or space ' '
+
+
+create /*testing invalid engine name*/ table integrate_test.t(a int) engine=unkown partition by hash(a);
+ERROR 1286 (42000): Unknown storage engine 'unkown', currently we only support InnoDB and TokuDB
+
+
+CREATE /*testing db name bigger than max_len(64)*/ DATABASE t01234567890123456789012345678901234567890123456789012345678901234567890123456789;
+ERROR 1059 (42000): Identifier name 't01234567890123456789012345678901234567890123456789012345678901234567890123456789' is too long
+
+CREATE /*testing table name bigger than max_len(64)*/ table integrate_test.t01234567890123456789012345678901234567890123456789012345678901234567890123456789(a int key);
+ERROR 1059 (42000): Identifier name 't01234567890123456789012345678901234567890123456789012345678901234567890123456789' is too long
 
 
 drop database integrate_test;

--- a/intergration/radon-test/t/create.test
+++ b/intergration/radon-test/t/create.test
@@ -1,3 +1,4 @@
+drop database if exists integrate_test;
 create database integrate_test DEFAULT CHARSET=utf8;
 
 create table integrate_test.t1 (b char(0)) partition by hash(b) DEFAULT CHARSET=utf8;
@@ -149,5 +150,18 @@ drop table if exists integrate_test.t1,integrate_test.t2,integrate_test.t3;
 
 CREATE TABLE integrate_test.t1 (v varchar(65535) key) DEFAULT CHARSET=utf8;
 DROP TABLE IF EXISTS integrate_test.t1;
+
+create /*testing bad database, database not exists*/ table not_existing_database.test (a int key);
+create /*testing table name with char '/', currently we don`t support it*/ table integrate_test.`a/a` (a int key);
+create /*testing table name with char ' ', currently we don`t support it*/ table integrate_test.`a a` (a int key);
+
+create /*testing invalid database name*/ database `database bad/name/db/`;
+create /*testing invalid database name with space char ' '*/ database `database bad`;
+create /*testing invalid database name with '/' */ database `database/bad`;
+
+create /*testing invalid engine name*/ table integrate_test.t(a int) engine=unkown partition by hash(a);
+
+CREATE /*testing db name bigger than max_len(64)*/ DATABASE t01234567890123456789012345678901234567890123456789012345678901234567890123456789;
+CREATE /*testing table name bigger than max_len(64)*/ table integrate_test.t01234567890123456789012345678901234567890123456789012345678901234567890123456789(a int key);
 
 drop database integrate_test;

--- a/src/ctl/v1/shard_test.go
+++ b/src/ctl/v1/shard_test.go
@@ -199,7 +199,11 @@ func TestCtlV1ShardBalanceAdviceGlobal(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	fakedbs, proxy, cleanup := proxy.MockProxy(log)
 	defer cleanup()
-	proxy.Router().AddForTest("sbtest", router.MockTableGConfig())
+	route := proxy.Router()
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableGConfig())
+	assert.Nil(t, err)
 
 	rdbs := &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -303,7 +307,11 @@ func TestCtlV1ShardBalanceAdviceSingle(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	fakedbs, proxy, cleanup := proxy.MockProxy(log)
 	defer cleanup()
-	proxy.Router().AddForTest("sbtest", router.MockTableSConfig())
+	route := proxy.Router()
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableSConfig())
+	assert.Nil(t, err)
 
 	rdbs := &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -407,7 +415,11 @@ func TestCtlV1ShardBalanceAdviceList(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	fakedbs, proxy, cleanup := proxy.MockProxy(log)
 	defer cleanup()
-	proxy.Router().AddForTest("sbtest", router.MockTableListConfig())
+	route := proxy.Router()
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableListConfig())
+	assert.Nil(t, err)
 
 	rdbs := &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -1256,6 +1268,9 @@ func TestCtlV1Globals(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	_, proxy, cleanup := proxy.MockProxy(log)
 	defer cleanup()
+	route := proxy.Router()
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	{
 		err := proxy.Router().AddForTest("sbtest", router.MockTableMConfig())

--- a/src/executor/ddl_executor_test.go
+++ b/src/executor/ddl_executor_test.go
@@ -35,7 +35,8 @@ func TestDDLExecutor(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// create table

--- a/src/executor/delete_executor_test.go
+++ b/src/executor/delete_executor_test.go
@@ -32,7 +32,9 @@ func TestDeleteExecutor(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// delete.

--- a/src/executor/engine/join_engine_test.go
+++ b/src/executor/engine/join_engine_test.go
@@ -239,7 +239,9 @@ func TestJoinEngine(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -476,7 +478,9 @@ func TestMaxRowErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableSConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -533,7 +537,9 @@ func TestGetFieldErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -576,7 +582,9 @@ func TestMockErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/engine/merge_engine_test.go
+++ b/src/executor/engine/merge_engine_test.go
@@ -81,7 +81,9 @@ func TestMergeEngine(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -132,7 +134,9 @@ func TestGenerateQueryErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	// Create scatter.

--- a/src/executor/engine/operator/aggregate_operator_test.go
+++ b/src/executor/engine/operator/aggregate_operator_test.go
@@ -31,7 +31,9 @@ func TestAggregateOperator(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -118,7 +120,9 @@ func TestAggregateAvgOperator(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -250,7 +254,9 @@ func TestAggregateNotPush(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -333,7 +339,9 @@ func TestAggregateGroup(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/engine/operator/limit_operator_test.go
+++ b/src/executor/engine/operator/limit_operator_test.go
@@ -66,7 +66,9 @@ func TestLimitOperator(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/engine/operator/orderby_operator_test.go
+++ b/src/executor/engine/operator/orderby_operator_test.go
@@ -70,7 +70,9 @@ func TestOrderByOperator(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -143,7 +145,9 @@ func TestOrderByError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/engine/union_engine_test.go
+++ b/src/executor/engine/union_engine_test.go
@@ -84,7 +84,9 @@ func TestUnionEngine(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.
@@ -177,7 +179,9 @@ func TestUnionEngineErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/executor_test.go
+++ b/src/executor/executor_test.go
@@ -36,7 +36,9 @@ func TestExecutor1(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	planTree := planner.NewPlanTree()

--- a/src/executor/insert_executor_test.go
+++ b/src/executor/insert_executor_test.go
@@ -33,7 +33,9 @@ func TestInsertExecutor(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// delete.

--- a/src/executor/others_executor_test.go
+++ b/src/executor/others_executor_test.go
@@ -33,7 +33,9 @@ func TestOthersExecutor(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// delete.

--- a/src/executor/select_executor_test.go
+++ b/src/executor/select_executor_test.go
@@ -29,7 +29,9 @@ func TestSelectExecutorErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/union_executor_test.go
+++ b/src/executor/union_executor_test.go
@@ -46,7 +46,9 @@ func TestUnionExecutorErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	// Create scatter and query handler.

--- a/src/executor/update_executor_test.go
+++ b/src/executor/update_executor_test.go
@@ -33,7 +33,9 @@ func TestUpdateExecutor(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	// delete.

--- a/src/planner/builder/aggregate_plan_test.go
+++ b/src/planner/builder/aggregate_plan_test.go
@@ -128,7 +128,9 @@ func TestAggregatePlan(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)
@@ -273,7 +275,10 @@ func TestAggregatePlanUpperCase(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)
@@ -332,7 +337,10 @@ func TestAggregatePlanHaving(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)
@@ -377,7 +385,10 @@ func TestAggregatePlanUnsupported(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)
@@ -471,7 +482,10 @@ func TestAggregatePlans(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)

--- a/src/planner/builder/builder_test.go
+++ b/src/planner/builder/builder_test.go
@@ -362,7 +362,9 @@ func TestProcessSelect(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
+		err := route.CreateDatabase(database)
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
 		assert.Nil(t, err)
 		for _, tcase := range tcases {
 			node, err := sqlparser.Parse(tcase.query)
@@ -464,7 +466,9 @@ func TestSelectDatabaseIsNull(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest("sbtest", router.MockTableMConfig())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest("sbtest", router.MockTableMConfig())
 		assert.Nil(t, err)
 		for _, tcase := range tcases {
 			node, err := sqlparser.Parse(tcase.query)
@@ -571,7 +575,9 @@ func TestSelectUnsupported(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig(), router.MockTableCConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig(), router.MockTableCConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -625,7 +631,9 @@ func TestSelectSupported(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for _, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -723,7 +731,9 @@ func TestSelectPlanAs(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableMConfig())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableMConfig())
 		assert.Nil(t, err)
 		for _, tcase := range tcases {
 			node, err := sqlparser.Parse(tcase.query)
@@ -751,7 +761,9 @@ func TestSelectDatabaseNotFound(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	databaseNull := ""
@@ -772,7 +784,9 @@ func TestUnsportStatement(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	databaseNull := ""
@@ -798,7 +812,9 @@ func TestSelectPlanGlobal(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableGConfig(), router.MockTableG1Config())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableGConfig(), router.MockTableG1Config())
 		assert.Nil(t, err)
 		for _, query := range querys {
 			node, err := sqlparser.Parse(query)
@@ -884,7 +900,9 @@ func TestSelectPlanJoin(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableGConfig(), router.MockTableBConfig(), router.MockTableG1Config())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableGConfig(), router.MockTableBConfig(), router.MockTableG1Config())
 		assert.Nil(t, err)
 		for _, tcase := range tcases {
 			node, err := sqlparser.Parse(tcase.query)
@@ -925,7 +943,9 @@ func TestSelectPlanJoinErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableGConfig(), router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableGConfig(), router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -1025,7 +1045,9 @@ func TestProcessUnion(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
 		assert.Nil(t, err)
 		for _, tcase := range tcases {
 			node, err := sqlparser.Parse(tcase.query)
@@ -1069,7 +1091,9 @@ func TestUnionUnsupported(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -1094,7 +1118,9 @@ func TestGenerateFieldQuery(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -1129,7 +1155,9 @@ func TestSelectPlanList(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableListConfig(), router.MockTableList1Config())
+		err := route.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableListConfig(), router.MockTableList1Config())
 		assert.Nil(t, err)
 		for i, query := range querys {
 			node, err := sqlparser.Parse(query)
@@ -1172,7 +1200,9 @@ func TestSelectSupportedPlanList(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
 		router.MockTableGConfig(), router.MockTableListConfig())
 	assert.Nil(t, err)
 	for _, query := range querys {

--- a/src/planner/builder/expr_test.go
+++ b/src/planner/builder/expr_test.go
@@ -42,7 +42,9 @@ func TestGetDMLRouting(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableBConfig(), router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableBConfig(), router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -71,7 +73,9 @@ func TestGetDMLRoutingErr(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	for _, testcase := range testcases {
@@ -97,7 +101,9 @@ func TestParserWhereOrJoinExprs(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -130,7 +136,9 @@ func TestWhereFilters(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -160,7 +168,9 @@ func TestWhereFiltersError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -205,7 +215,9 @@ func TestParserHaving(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -244,7 +256,9 @@ func TestParserHavingError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -275,7 +289,9 @@ func TestReplaceCol(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)

--- a/src/planner/builder/from_test.go
+++ b/src/planner/builder/from_test.go
@@ -25,7 +25,9 @@ func TestScanTableExprs(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableCConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableCConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	// single table.
 	{
@@ -352,7 +354,9 @@ func TestScanTableExprsList(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
 		router.MockTableCConfig(), router.MockTableGConfig(), router.MockTableListConfig())
 	assert.Nil(t, err)
 
@@ -652,7 +656,9 @@ func TestScanTableExprsListErrorDebug(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
 		router.MockTableCConfig(), router.MockTableGConfig(), router.MockTableListConfig())
 	assert.Nil(t, err)
 
@@ -722,7 +728,9 @@ func TestScanTableExprsError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -768,7 +776,9 @@ func TestScanTableExprsListError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(),
 		router.MockTableGConfig(), router.MockTableListConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {

--- a/src/planner/builder/orderby_plan_test.go
+++ b/src/planner/builder/orderby_plan_test.go
@@ -37,7 +37,9 @@ func TestOrderByPlan(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for _, query := range querys {
 		tree, err := sqlparser.Parse(query)
@@ -73,7 +75,9 @@ func TestOrderByPlanError(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		tree, err := sqlparser.Parse(query)

--- a/src/planner/builder/plan_node_test.go
+++ b/src/planner/builder/plan_node_test.go
@@ -31,7 +31,9 @@ func TestPushOrderBy(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -71,7 +73,9 @@ func TestPushOrderByError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -110,7 +114,9 @@ func TestPushLimit(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -142,7 +148,9 @@ func TestPushLimitError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -169,7 +177,9 @@ func TestPushMisc(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {

--- a/src/planner/builder/project_test.go
+++ b/src/planner/builder/project_test.go
@@ -26,7 +26,9 @@ func TestParserSelectExprsSubquery(t *testing.T) {
 	database := "sbtest"
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -51,7 +53,9 @@ func TestGetSelectExprs(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -89,7 +93,9 @@ func TestCheckGroupBy(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -128,7 +134,9 @@ func TestCheckGroupByError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -167,7 +175,9 @@ func TestCheckDistinct(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -204,7 +214,9 @@ func TestCheckDistinctError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -239,7 +251,9 @@ func TestSelectExprs(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for _, query := range querys {
@@ -278,7 +292,9 @@ func TestSelectExprsError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 
 	for i, query := range querys {
@@ -310,7 +326,9 @@ func TestReplaceSelect(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)

--- a/src/planner/builder/sqlparser_test.go
+++ b/src/planner/builder/sqlparser_test.go
@@ -517,7 +517,9 @@ func TestSQLSelectAggregator(t *testing.T) {
 	}
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 	for _, query := range querys {
 		log.Debug("query:%s", query)
@@ -559,7 +561,9 @@ func TestSQLSelectRewritten(t *testing.T) {
 	}
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
-	err := route.AddForTest("sbtest", router.MockTableMConfig())
+	err := route.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = route.AddForTest("sbtest", router.MockTableMConfig())
 	assert.Nil(t, err)
 	for _, query := range querys {
 		log.Debug("query:%s", query)

--- a/src/planner/ddl_plan_test.go
+++ b/src/planner/ddl_plan_test.go
@@ -55,7 +55,9 @@ func TestDDLPlan1(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableGConfig(), router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableGConfig(), router.MockTableSConfig())
 	assert.Nil(t, err)
 	planTree := NewPlanTree()
 	for i, query := range querys {
@@ -102,7 +104,9 @@ func TestDROPPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableGConfig(), router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableGConfig(), router.MockTableSConfig())
 	assert.Nil(t, err)
 	planTree := NewPlanTree()
 	for i, query := range querys {
@@ -180,7 +184,9 @@ func TestDDLAlterError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)
@@ -320,7 +326,9 @@ func TestDDLPlanCreateIndex(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)
@@ -378,7 +386,9 @@ func TestDDLPlanWithQuote(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig(), router.MockTableBConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)
@@ -422,7 +432,9 @@ func TestDDLPlanWithSameColumn(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)
@@ -476,7 +488,9 @@ func TestDDLPlanWithRename(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableRConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableRConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)
@@ -510,7 +524,9 @@ func TestDDLPlanWithRenameNoshard(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableSConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		log.Debug("%v", query)

--- a/src/planner/delete_plan_test.go
+++ b/src/planner/delete_plan_test.go
@@ -126,7 +126,9 @@ func TestDeletePlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig(), router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig(), router.MockTableSConfig())
 	assert.Nil(t, err)
 	planTree := NewPlanTree()
 	for i, query := range querys {
@@ -168,7 +170,9 @@ func TestDeleteUnsupportedPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -194,7 +198,9 @@ func TestDeleteErrorPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	databaseNull := ""
 	node, err := sqlparser.Parse(query)

--- a/src/planner/insert_plan_test.go
+++ b/src/planner/insert_plan_test.go
@@ -75,7 +75,9 @@ func TestInsertPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -140,7 +142,9 @@ func TestInsertPlanSort(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableDeadLockConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableDeadLockConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -190,7 +194,9 @@ func TestInsertUnsupportedPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -216,7 +222,9 @@ func TestInsertPlanBench(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	{
@@ -278,7 +286,9 @@ func TestReplacePlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -323,7 +333,9 @@ func TestReplaceUnsupportedPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -349,7 +361,9 @@ func TestReplacePlanBench(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	{
@@ -380,7 +394,9 @@ func TestInsertPlanError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	databaseNull := ""
 	for _, query := range querys {
@@ -456,7 +472,9 @@ func TestInsertPlanGlobal(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		// database is nil
@@ -541,7 +559,9 @@ func TestReplacePlanGlobal(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		// database is nil
@@ -611,7 +631,9 @@ func TestInsertPlanSingle(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableSConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		// database is nil
@@ -681,7 +703,9 @@ func TestReplacePlanSingle(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableSConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableSConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		// database is nil

--- a/src/planner/others_plan_test.go
+++ b/src/planner/others_plan_test.go
@@ -112,7 +112,9 @@ func TestOthersPlanChecksumTable(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	planTree := NewPlanTree()
 	for i, query := range querys {

--- a/src/planner/planner_test.go
+++ b/src/planner/planner_test.go
@@ -27,7 +27,9 @@ func TestPlanner(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -58,7 +60,9 @@ func TestPlannerError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableAConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableAConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -448,7 +448,9 @@ func TestSelectPlan(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
+		err := route.CreateDatabase(database)
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
 		assert.Nil(t, err)
 		for i, query := range querys {
 			node, err := sqlparser.Parse(query)
@@ -486,7 +488,9 @@ func TestSelectUnsupportedPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableGConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)

--- a/src/planner/union_plan_test.go
+++ b/src/planner/union_plan_test.go
@@ -62,7 +62,9 @@ func TestUnionPlan(t *testing.T) {
 		route, cleanup := router.MockNewRouter(log)
 		defer cleanup()
 
-		err := route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
+		err := route.CreateDatabase(database)
+		assert.Nil(t, err)
+		err = route.AddForTest(database, router.MockTableMConfig(), router.MockTableBConfig(), router.MockTableSConfig(), router.MockTableGConfig())
 		assert.Nil(t, err)
 		for i, query := range querys {
 			node, err := sqlparser.Parse(query)

--- a/src/planner/update_plan_test.go
+++ b/src/planner/update_plan_test.go
@@ -61,7 +61,9 @@ func TestUpdatePlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	planTree := NewPlanTree()
 	for i, query := range querys {
@@ -103,7 +105,9 @@ func TestUpdateUnsupportedPlan(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 	for i, query := range querys {
 		node, err := sqlparser.Parse(query)
@@ -129,7 +133,9 @@ func TestUpdateWithNoDatabase(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -154,7 +160,9 @@ func TestUpdatePlanError(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -179,7 +187,9 @@ func TestUpdateShardKey(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -204,7 +214,9 @@ func TestUpdateNoDatabase(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)
@@ -229,7 +241,9 @@ func TestUpdateDatabaseNotFound(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
-	err := route.AddForTest(database, router.MockTableMConfig())
+	err := route.CreateDatabase(database)
+	assert.Nil(t, err)
+	err = route.AddForTest(database, router.MockTableMConfig())
 	assert.Nil(t, err)
 
 	node, err := sqlparser.Parse(query)

--- a/src/plugins/autoincrement/autoincrement_test.go
+++ b/src/plugins/autoincrement/autoincrement_test.go
@@ -122,9 +122,11 @@ func TestPluginAutoIncrement(t *testing.T) {
 	route, cleanup := router.MockNewRouter(log)
 	defer cleanup()
 
+	err := route.CreateDatabase(db)
+	assert.Nil(t, err)
 	// Plugin.
 	autoplug := NewAutoIncrement(log, route)
-	err := autoplug.Init()
+	err = autoplug.Init()
 	assert.Nil(t, err)
 	defer autoplug.Close()
 

--- a/src/proxy/ddl.go
+++ b/src/proxy/ddl.go
@@ -21,27 +21,21 @@ import (
 	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
 )
 
-var (
-	supportEngines = []string{
-		"innodb",
-		"tokudb",
-	}
-)
-
-func checkEngine(ddl *sqlparser.DDL) {
-	check := false
+func checkEngine(ddl *sqlparser.DDL) error {
 	engine := ddl.TableSpec.Options.Engine
-	for _, eng := range supportEngines {
-		if eng == strings.ToLower(engine) {
-			check = true
-			break
-		}
+	if engine == "" {
+		// default set engine InnoDB if engine is empty.
+		ddl.TableSpec.Options.Engine = "InnoDB"
+		return nil
 	}
 
-	// Change the storage engine to InnoDB.
-	if !check {
-		ddl.TableSpec.Options.Engine = "InnoDB"
+	// see: https://github.com/mysql/mysql-server/blob/5.7/sql/sql_yacc.yy#L6181
+	// for mysql support engine type(named: enum legacy_db_type)
+	// see: https://github.com/mysql/mysql-server/blob/5.7/sql/handler.h#L397
+	if strings.ToLower(engine) == "innodb" || strings.ToLower(engine) == "tokudb" {
+		return nil
 	}
+	return sqldb.NewSQLError(sqldb.ER_UNKNOWN_STORAGE_ENGINE, engine)
 }
 
 func tryGetShardKey(ddl *sqlparser.DDL) (string, error) {
@@ -112,12 +106,6 @@ func tryGetShardKey(ddl *sqlparser.DDL) (string, error) {
 	return "", fmt.Errorf("The unique/primary constraint shoule be defined or add 'PARTITION BY HASH' to mandatory indication")
 }
 
-func checkDatabaseExists(database string, router *router.Router) bool {
-	tblList := router.Tables()
-	_, ok := tblList[database]
-	return ok
-}
-
 func checkTableExists(database string, table string, router *router.Router) bool {
 	tblList := router.Tables()
 	tables, ok := tblList[database]
@@ -184,16 +172,22 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 
 	switch ddl.Action {
 	case sqlparser.CreateDBStr:
-		if node.IfNotExists && checkDatabaseExists(database, route) {
-			return &sqltypes.Result{}, nil
+		if err := route.CheckDatabase(database); err == nil {
+			// If database already exists and the flag is "if not exists", return
+			if node.IfNotExists {
+				return &sqltypes.Result{}, nil
+			}
 		}
 		if err := route.CreateDatabase(database); err != nil {
 			return nil, err
 		}
 		return spanner.ExecuteScatter(query)
 	case sqlparser.DropDBStr:
-		if node.IfExists && !checkDatabaseExists(database, route) {
-			return &sqltypes.Result{}, nil
+		if err := route.CheckDatabase(database); err != nil {
+			// If database not exists and the flag is "if exists", return
+			if node.IfExists {
+				return &sqltypes.Result{}, nil
+			}
 		}
 		// Execute the ddl.
 		qr, err := spanner.ExecuteScatter(query)
@@ -212,8 +206,8 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 		shardKey := ddl.PartitionName
 		tableType := router.TableTypeUnknown
 
-		if !checkDatabaseExists(database, route) {
-			return nil, sqldb.NewSQLError(sqldb.ER_NO_DB_ERROR)
+		if err := route.CheckDatabase(database); err != nil {
+			return nil, err
 		}
 
 		// Check table exists.
@@ -222,7 +216,9 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 		}
 
 		// Check engine.
-		checkEngine(ddl)
+		if err := checkEngine(ddl); err != nil {
+			return nil, err
+		}
 
 		autoinc, err := autoincrement.GetAutoIncrement(node)
 		if err != nil {
@@ -303,9 +299,9 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 				query = fmt.Sprintf("drop table %s.%s", db, table)
 			}
 
-			// Check the database and table is exists.
-			if !checkDatabaseExists(db, route) {
-				return nil, sqldb.NewSQLError(sqldb.ER_BAD_DB_ERROR, db)
+			// Check the database
+			if err := route.CheckDatabase(db); err != nil {
+				return nil, err
 			}
 
 			// Check table exists.
@@ -332,9 +328,9 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 		sqlparser.AlterAddColumnStr, sqlparser.AlterDropColumnStr, sqlparser.AlterModifyColumnStr,
 		sqlparser.TruncateTableStr:
 
-		// Check the database and table is exists.
-		if !checkDatabaseExists(database, route) {
-			return nil, sqldb.NewSQLError(sqldb.ER_BAD_DB_ERROR, database)
+		// Check the database
+		if err := route.CheckDatabase(database); err != nil {
+			return nil, err
 		}
 
 		table := ddl.Table.Name.String()
@@ -355,8 +351,8 @@ func (spanner *Spanner) handleDDL(session *driver.Session, query string, node *s
 		toTable := ddl.NewName.Name.String()
 
 		// Check the database, fromTable is exists, toTable is not exists.
-		if !checkDatabaseExists(database, route) {
-			return nil, sqldb.NewSQLError(sqldb.ER_BAD_DB_ERROR, database)
+		if err := route.CheckDatabase(database); err != nil {
+			return nil, err
 		}
 
 		if !checkTableExists(database, fromTable, route) {

--- a/src/proxy/ddl_test.go
+++ b/src/proxy/ddl_test.go
@@ -814,10 +814,12 @@ func TestProxyDDLCreateTableError(t *testing.T) {
 	querys := []string{
 		"create table t2(a int, partition int) PARTiITION BY hash(a)",
 		"create table dual(a int) partition by hash(a)",
+		"create table t(a int) engine=unkown partition by hash(a)",
 	}
 	results := []string{
 		"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use, syntax error at position 33 near 'partition' (errno 1149) (sqlstate 42000)",
 		"spanner.ddl.check.create.table[dual].error:not support (errno 1105) (sqlstate HY000)",
+		"Unknown storage engine 'unkown', currently we only support InnoDB and TokuDB (errno 1286) (sqlstate 42000)",
 	}
 
 	for i, query := range querys {

--- a/src/router/api_test.go
+++ b/src/router/api_test.go
@@ -22,7 +22,9 @@ func TestApiRules(t *testing.T) {
 
 	// add router of sbtest.A
 	{
-		err := router.addTable("sbtest", MockTableAConfig())
+		err := router.CreateDatabase("sbtest")
+		assert.Nil(t, err)
+		err = router.addTable("sbtest", MockTableAConfig())
 		assert.Nil(t, err)
 
 		tConf, err := router.TableConfig("sbtest", "A")
@@ -40,7 +42,8 @@ func TestApiPartitionRuleShift(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 
-	router.CreateDatabase("sbtest")
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -111,12 +114,14 @@ func TestApiPartitionRuleShift(t *testing.T) {
 }`
 		got := router.JSON()
 		assert.Equal(t, want, got)
+		log.Error("gry22222")
 	}
 
 	// Drop.
 	{
 		err := router.DropDatabase("sbtest")
 		assert.Nil(t, err)
+		log.Error("gry33333")
 	}
 }
 
@@ -124,7 +129,8 @@ func TestApiPartitionRuleShiftGlobal(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
-	router.CreateDatabase("sbtest")
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.G
 	{
@@ -238,10 +244,12 @@ func TestApiPartitionRuleShiftErrors(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
-		err := router.addTable("sbtest", MockTableAConfig())
+		err = router.addTable("sbtest", MockTableAConfig())
 		assert.Nil(t, err)
 
 		tConf, err := router.TableConfig("sbtest", "A")
@@ -334,7 +342,8 @@ func TestApiReLoad(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 
-	router.CreateDatabase("sbtest")
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A.
 	{

--- a/src/router/router_test.go
+++ b/src/router/router_test.go
@@ -77,6 +77,8 @@ func TestRouterAdd(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// router
 	{
@@ -139,6 +141,8 @@ func TestRouteraddGlobal(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// router
 	{
@@ -177,6 +181,8 @@ func TestRouteraddSingle(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// router
 	{
@@ -203,6 +209,8 @@ func TestRouterRemove(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 	// router
 	{
 		err := router.removeTable("", MockTableCConfig().Name)
@@ -255,6 +263,8 @@ func TestRouterLookup(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -272,6 +282,8 @@ func TestRouterLookupError(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -303,6 +315,8 @@ func TestRouterShardKey(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -320,6 +334,8 @@ func TestRouterPartitionType(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	{
 		// add router of sbtest.A
@@ -343,6 +359,8 @@ func TestRouterShardKeyError(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -430,6 +448,8 @@ func TestRouterTableConfig(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// add router of sbtest.A
 	{
@@ -447,7 +467,9 @@ func TestRouterGetIndex(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
-	err := router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig())
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig())
 	assert.Nil(t, err)
 	// hash.
 	{
@@ -477,7 +499,9 @@ func TestRouterGetIndexError(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
-	err := router.AddForTest("sbtest", MockTableMConfig())
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = router.AddForTest("sbtest", MockTableMConfig())
 	assert.Nil(t, err)
 	// no database.
 	{
@@ -513,7 +537,9 @@ func TestRouterGetSegments(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
-	err := router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig(), MockTableListConfig())
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig(), MockTableListConfig())
 	assert.Nil(t, err)
 	// hash.
 	{
@@ -576,7 +602,9 @@ func TestRouterGetSegmentsError(t *testing.T) {
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
 	assert.NotNil(t, router)
-	err := router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig())
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
+	err = router.AddForTest("sbtest", MockTableGConfig(), MockTableMConfig(), MockTableSConfig())
 	assert.Nil(t, err)
 	// no database.
 	{
@@ -624,13 +652,16 @@ func TestRouterTables(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// sbtest with tables.
-	err := router.AddForTest("sbtest", MockTableMConfig())
+	err = router.AddForTest("sbtest", MockTableMConfig())
 	assert.Nil(t, err)
 
 	// tables is empty.
 	router.CreateDatabase("nulldatabase")
+	assert.Nil(t, err)
 
 	want := make(map[string][]string)
 	want["sbtest"] = []string{"A"}
@@ -643,9 +674,11 @@ func TestRouterGetRenameTableConfig(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// sbtest with tables.
-	err := router.AddForTest("sbtest", MockTableMConfig())
+	err = router.AddForTest("sbtest", MockTableMConfig())
 	assert.Nil(t, err)
 
 	_, err = router.getRenameTableConfig("sbtest", "A", "B")
@@ -665,9 +698,11 @@ func TestRouterIsPartitionHash(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	router, cleanup := MockNewRouter(log)
 	defer cleanup()
+	err := router.CreateDatabase("sbtest")
+	assert.Nil(t, err)
 
 	// sbtest with tables.
-	err := router.AddForTest("sbtest", MockTableMConfig())
+	err = router.AddForTest("sbtest", MockTableMConfig())
 	assert.Nil(t, err)
 
 	isHash := router.IsPartitionHash(methodTypeHash)

--- a/src/vendor/github.com/xelabs/go-mysqlstack/sqldb/constants.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/sqldb/constants.go
@@ -270,7 +270,7 @@ var CharacterSetMap = map[string]uint8{
 
 const (
 	// Error codes for server-side errors.
-	// Originally found in include/mysql/mysqld_error.h
+	// Originally found in include/mysqld_error.h
 
 	// ER_ERROR_FIRST enum.
 	ER_ERROR_FIRST uint16 = 1000
@@ -293,6 +293,9 @@ const (
 	// ER_BAD_DB_ERROR enum.
 	ER_TABLE_EXISTS_ERROR = 1050
 
+	// ER_TOO_LONG_IDENT enum
+	ER_TOO_LONG_IDENT = 1059
+
 	// ER_KILL_DENIED_ERROR enum
 	ER_KILL_DENIED_ERROR = 1095
 
@@ -310,6 +313,9 @@ const (
 
 	// ER_SPECIFIC_ACCESS_DENIED_ERROR enum.
 	ER_SPECIFIC_ACCESS_DENIED_ERROR = 1227
+
+	// ER_UNKNOWN_STORAGE_ENGINE enum.
+	ER_UNKNOWN_STORAGE_ENGINE = 1286
 
 	// ER_OPTION_PREVENTS_STATEMENT enum.
 	ER_OPTION_PREVENTS_STATEMENT = 1290
@@ -340,12 +346,14 @@ var SQLErrors = map[uint16]*SQLError{
 	ER_NO_DB_ERROR:                  &SQLError{Num: ER_NO_DB_ERROR, State: "3D000", Message: "No database selected"},
 	ER_BAD_DB_ERROR:                 &SQLError{Num: ER_BAD_DB_ERROR, State: "42000", Message: "Unknown database '%-.192s'"},
 	ER_TABLE_EXISTS_ERROR:           &SQLError{Num: ER_TABLE_EXISTS_ERROR, State: "42S01", Message: "Table '%s' already exists"},
+	ER_TOO_LONG_IDENT:               &SQLError{Num: ER_TOO_LONG_IDENT, State: "42000", Message: "Identifier name '%-.100s' is too long"},
 	ER_KILL_DENIED_ERROR:            &SQLError{Num: ER_KILL_DENIED_ERROR, State: "HY000", Message: "You are not owner of thread '%-.192s'"},
 	ER_UNKNOWN_ERROR:                &SQLError{Num: ER_UNKNOWN_ERROR, State: "HY000", Message: "%v"},
 	ER_HOST_NOT_PRIVILEGED:          &SQLError{Num: ER_HOST_NOT_PRIVILEGED, State: "HY000", Message: "Host '%-.64s' is not allowed to connect to this MySQL server"},
 	ER_NO_SUCH_TABLE:                &SQLError{Num: ER_NO_SUCH_TABLE, State: "42S02", Message: "Table '%s' doesn't exist"},
 	ER_SYNTAX_ERROR:                 &SQLError{Num: ER_SYNTAX_ERROR, State: "42000", Message: "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use, %s"},
 	ER_SPECIFIC_ACCESS_DENIED_ERROR: &SQLError{Num: ER_SPECIFIC_ACCESS_DENIED_ERROR, State: "42000", Message: "Access denied; you need (at least one of) the %-.128s privilege(s) for this operation"},
+	ER_UNKNOWN_STORAGE_ENGINE:       &SQLError{Num: ER_UNKNOWN_STORAGE_ENGINE, State: "42000", Message: "Unknown storage engine '%v', currently we only support InnoDB and TokuDB"},
 	ER_OPTION_PREVENTS_STATEMENT:    &SQLError{Num: ER_OPTION_PREVENTS_STATEMENT, State: "42000", Message: "The MySQL server is running with the %s option so it cannot execute this statement"},
 	ER_MALFORMED_PACKET:             &SQLError{Num: ER_MALFORMED_PACKET, State: "HY000", Message: "Malformed communication packet, err: %v"},
 	CR_SERVER_LOST:                  &SQLError{Num: CR_SERVER_LOST, State: "HY000", Message: ""},


### PR DESCRIPTION
[summary]
fix bug list:
1. When create table with unkown database, we get wrong msg
```
mysql> create table not_existing_database.test (a int);
ERROR 1046 (3D000): No database selected
```
in mysql we get:
```
mysql> create table not_existing_database.test (a int);
ERROR 1049 (42000): Unknown database 'not_existing_database'
```
2. Wrong handling on table/DB name with char space '  ' or '/', in mysql, both of them will be converted by func strconvert() in sql/strfunc.cc.
see: https://github.com/mysql/mysql-server/blob/5.7/sql/strfunc.cc#L274

    1) in mysql, if last char is space in tbl/db name, mysql will return an error, otherwise char space
will be converted to `@0020f` by func check_table_name() in sql/table.cc.
see: https://github.com/mysql/mysql-server/blob/5.7/sql/table.cc#L4284
    2) char `/` will be converted to `@002f` by func strconvert(), e.g.:`a/a` will first converted to `a@002fa` and then write to disk.
see: https://github.com/mysql/mysql-server/blob/5.7/sql/sql_table.cc#L518

In radon, we support both, this is not a correct way. As we did't have a function like strconver(), we don't support them currently(Ohter special characters like `?`, `-` also have the same problem, we should find a better way to solve this problem).

3. When create table fail during write to disk, the operation returned without clear cache in map.
```
mysql> show tables;
+----------------+
| Tables_in_test |
+----------------+
| tx             |
| a              |
+----------------+
2 rows in set (0.00 sec)

mysql> create table `a/a` (a int key);
ERROR 1105 (HY000): open bin/radon-meta/test/a/a.json: no such file or directory
mysql> show tables;
+----------------+
| Tables_in_test |
+----------------+
| a              |
| tx             |
| a/a            |
+----------------+
3 rows in set (0.01 sec)
```
4. When create table with an error engine opt, radon did not return error msg. The code in proxy/ddl.go next is wrong.
```
 41     // Change the storage engine to InnoDB.
 42     if !check {
 43         ddl.TableSpec.Options.Engine = "InnoDB"
 44     }
```
Now radon:
```
mysql> create table t(a int key) engine=ixx;
Query OK, 0 rows affected (2.60 sec)
```
Actually we should get:
```
mysql> create table t(a int) engine=ixx;
ERROR 1286 (42000): Unknown storage engine 'ixx'
```
In mysql, the error msg got from :
https://github.com/mysql/mysql-server/blob/5.7/sql/sql_yacc.yy#L6181

For mysql support engine type(named: enum legacy_db_type)
see: https://github.com/mysql/mysql-server/blob/5.7/sql/handler.h#L397

5. The len of db/table name should be limited.
In mysql, the limit NAME_CHAR_LEN = 64,
see check_table_name() in:
https://github.com/mysql/mysql-server/blob/5.7/sql/table.cc#L4255
and check_and_convert_db_name() in:
https://github.com/mysql/mysql-server/blob/5.7/sql/table.cc#L4207

[test case]
sqlparser/ddl_test.go
router/api_test.go
router/frm_test.go

[patch codecov]
proxy/ddl.go        94.6%
router/frm.go       86.4%
router/router.go    92.6%