### PR TITLE
proxy: more detailed explain error output #644

### DIFF
--- a/src/proxy/explain.go
+++ b/src/proxy/explain.go
@@ -75,12 +75,7 @@ func (spanner *Spanner) handleExplain(session *driver.Session, query string, nod
 	planTree, err := simOptimizer.BuildPlanTree()
 	if err != nil {
 		log.Error("proxy.explain.error:%+v", err)
-		msg := fmt.Sprintf("unsupported: cannot.explain.the.query:%s", cutQuery)
-		row := []sqltypes.Value{
-			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(msg)),
-		}
-		qr.Rows = append(qr.Rows, row)
-		return qr, nil
+		return nil, err
 	}
 
 	if len(planTree.Plans()) > 0 {

--- a/src/proxy/explain_test.go
+++ b/src/proxy/explain_test.go
@@ -250,11 +250,11 @@ func TestProxyExplainError(t *testing.T) {
 	{
 		client, err := driver.NewConn("mock", "mock", address, "test", "utf8")
 		assert.Nil(t, err)
-		query := "explain select xx sdf"
-		qr, err := client.FetchAll(query, -1)
-		assert.Nil(t, err)
-		want := "unsupported: cannot.explain.the.query: select xx sdf"
-		got := string(qr.Rows[0][0].Raw())
+		query := "explain select xx from sdf"
+		_, err = client.FetchAll(query, -1)
+		assert.NotNil(t, err)
+		want := "Table 'test.sdf' doesn't exist (errno 1146) (sqlstate 42S02)"
+		got := err.Error()
 		assert.Equal(t, want, got)
 	}
 


### PR DESCRIPTION
In `Radon`:
```
mysql> explain select * from test.t;
+--------------------------------------------------------+
| EXPLAIN                                                |
+--------------------------------------------------------+
| unsupported: cannot.explain.the.query: select * from t |
+--------------------------------------------------------+
1 row in set (0.00 sec)
```

In `MySQL`:
```
mysql> explain select * from test.t;
ERROR 1146 (42S02): Table 'test.t' doesn't exist
```

[summary]
We need more detail about the explain error output, just like MySQL.

[test case]
src/proxy/explain_test.go

[patch codecov]
src/proxy/explain.go 91.7%