### PR TITLE
*: add RollbackPhaseOne at the phase one.

### DIFF
--- a/src/proxy/execute.go
+++ b/src/proxy/execute.go
@@ -89,8 +89,8 @@ func (spanner *Spanner) ExecuteSingleStmtTxnTwoPC(session *driver.Session, datab
 	executors := executor.NewTree(log, plans, txn)
 	qr, err := executors.Execute()
 	if err != nil {
-		if x := txn.Rollback(); x != nil {
-			log.Error("spanner.execute.2pc.error.to.rollback.still.error:[%v]", x)
+		if x := txn.RollbackPhaseOne(); x != nil {
+			log.Error("spanner.execute.2pc.error.to.rollback.phaseOne.still.error:[%v]", x)
 		}
 		return nil, err
 	}

--- a/src/proxy/execute_test.go
+++ b/src/proxy/execute_test.go
@@ -127,6 +127,18 @@ func TestProxyExecute2PCError(t *testing.T) {
 		_, err = client.FetchAll(query, -1)
 		assert.NotNil(t, err)
 	}
+
+	// Insert with 2PC but execute error, RollbackPhaseOne error.
+	{
+		fakedbs.AddQueryErrorPattern("XA END .*", sqldb.NewSQLError1(1397, "XAE04", "XAER_NOTA: Unknown XID"))
+		proxy.conf.Proxy.TwopcEnable = true
+		client, err := driver.NewConn("mock", "mock", address, "", "utf8")
+		assert.Nil(t, err)
+		query := "insert into test.t1 (id, b) values(1,2),(3,4)"
+		fakedbs.AddQuery(query, fakedb.Result3)
+		_, err = client.FetchAll(query, -1)
+		assert.NotNil(t, err)
+	}
 }
 
 func TestProxyExecute2PCCommitError(t *testing.T) {


### PR DESCRIPTION
[summary]
RollbackPhaseOne used to rollback when the SQL return error at the phase one.
won't do `XA PREPARE` which will write log to binlog, especially when large Transactions happen.

[test case]
src/backend/xa_test.go
[patch codecov]
src/backend/txn.go 89.8%
src/proxy/execute.go 87.8%