### PR TITLE
proxy: support allow ip regexp in config file #620

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ large-capacity database、automatic plane split table、 scalable and strong con
 ## SQL Layer
 
 ### SQL support
-On SQL syntax level, RadonDB Fully compatible with MySQL.You can view all of the SQL features RadonDB supports here  [radon_sql_support](docs/radon_sql_support.md)
+On SQL syntax level, RadonDB Fully compatible with MySQL.You can view all of the SQL features RadonDB supports here  [radon_sql_statements_manual](docs/radon_sql_statements_manual.md)
 
 ###  SQL parser, planner, executor
 

--- a/conf/conf.json.sample
+++ b/conf/conf.json.sample
@@ -1,5 +1,6 @@
 {
         "proxy": {
+                "allowip":["ip list(default wildcard *,allow all ip to connect to radon), you should define ip by yourself, e.g.", "192.168.0.1", "*", "172.10.[0-9]+.[0-9]+", "192.168.*"],
                 "endpoint": "{RADON-HOST}:{PORT}",
                 "meta-dir": "{RADON-META-DIR}",
                 "twopc-enable": false,

--- a/conf/radon.default.json
+++ b/conf/radon.default.json
@@ -1,5 +1,6 @@
 {
         "proxy": {
+                "allowip":["*"],
                 "endpoint": ":3308",
                 "meta-dir": "bin/radon-meta",
                 "peer-address": ":8080"

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,7 +61,7 @@ Request: {
 			"ddl-timeout":     The execution timeout(in millisecond) for DDL statements,
 			"query-timeout":   The execution timeout(in millisecond) for DML statements,
 			"twopc-enable":    Enables(true or false) radon two phase commit, for distrubuted transaction,
-			"allowip":         ["allow-ip-1", "allow-ip-2"],
+			"allowip":         ["allow-ip-1", "allow-ip-2", "allow-ip-regexp"],
 			"audit-mode":      The audit log mode, "N": disabled, "R": read enabled, "W": write enabled, "A": read/write enabled,
 			"blocks-readonly": The size of a block when create hash tables,
 			"load-balance":    Enables(0 or 1) load balance, for read-write separation.
@@ -76,7 +76,7 @@ Request: {
 ```
 `Example: `
 ```
-$ curl -i -H 'Content-Type: application/json' -X PUT -d '{"max-connections":1024, "max-result-size":1073741824, "max-join-rows":32768, "ddl-timeout":3600, "query-timeout":600, "twopc-enable":true, "load-balance" 1, "allowip": ["127.0.0.1", "127.0.0.2"]}' http://127.0.0.1:8080/v1/radon/config
+$ curl -i -H 'Content-Type: application/json' -X PUT -d '{"max-connections":1024, "max-result-size":1073741824, "max-join-rows":32768, "ddl-timeout":3600, "query-timeout":600, "twopc-enable":true, "load-balance" 1, "allowip": ["127.0.0.1", "127.0.0.2", "172.10.[0-9]+.[0-9]+"]}' http://127.0.0.1:8080/v1/radon/config
 
 ---Response---
 HTTP/1.1 200 OK

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -24,7 +24,7 @@ const (
 
 // ProxyConfig tuple.
 type ProxyConfig struct {
-	IPS         []string `json:"allowip,omitempty"`
+	IPS         []string `json:"allowip"`
 	MetaDir     string   `json:"meta-dir"`
 	Endpoint    string   `json:"endpoint"`
 	TwopcEnable bool     `json:"twopc-enable"`

--- a/src/proxy/iptable.go
+++ b/src/proxy/iptable.go
@@ -9,6 +9,7 @@
 package proxy
 
 import (
+	"regexp"
 	"sync"
 
 	"config"
@@ -26,7 +27,7 @@ type IPTable struct {
 	mu      sync.RWMutex
 	log     *xlog.Log
 	conf    *config.ProxyConfig
-	iptable map[string]*IP
+	iptable map[string]interface{}
 }
 
 // NewIPTable creates a new IPTable.
@@ -34,25 +35,48 @@ func NewIPTable(log *xlog.Log, conf *config.ProxyConfig) *IPTable {
 	ipt := &IPTable{
 		log:     log,
 		conf:    conf,
-		iptable: make(map[string]*IP),
+		iptable: make(map[string]interface{}),
 	}
 
 	if conf.IPS != nil {
 		for _, ip := range conf.IPS {
-			IP := &IP{ip: ip}
-			ipt.iptable[ip] = IP
+			if err := addToIPTable(ipt, ip); err != nil {
+				log.Error("add ip failed during new iptable: ip[%s], err[%+v]", ip, err)
+			}
 		}
 	}
 	return ipt
 }
 
-// Add used to add a ip to table.
-func (ipt *IPTable) Add(ip string) {
+// isWildcardIP used to judge if ip is a regexp and return true, otherwise return false
+func isWildcardIP(ip string) bool {
+	return regexp.QuoteMeta(ip) != ip
+}
+
+// addToIPTable is used to add an ip to iptable
+func addToIPTable(ipt *IPTable, ip string) error {
+	if isWildcardIP(ip) {
+		if ip == "*" {
+			ip = "." + ip
+		}
+		reg, err := regexp.Compile(ip)
+		if err != nil {
+			return err
+		}
+		ipt.iptable[ip] = reg
+	} else {
+		IP := &IP{ip: ip}
+		ipt.iptable[ip] = IP
+	}
+	return nil
+}
+
+// Add used to add an ip to iptable.
+func (ipt *IPTable) Add(ip string) error {
 	ipt.log.Warning("proxy.iptable.add:%s", ip)
 	ipt.mu.Lock()
 	defer ipt.mu.Unlock()
-	IP := &IP{ip: ip}
-	ipt.iptable[ip] = IP
+	return addToIPTable(ipt, ip)
 }
 
 // Remove used to remove a ip from table.
@@ -60,34 +84,48 @@ func (ipt *IPTable) Remove(ip string) {
 	ipt.log.Warning("proxy.iptable.remove:%s", ip)
 	ipt.mu.Lock()
 	defer ipt.mu.Unlock()
+
+	if ip == "*" {
+		ip = "." + ip
+	}
 	delete(ipt.iptable, ip)
 }
 
 // Refresh used to refresh the table.
-func (ipt *IPTable) Refresh() {
+func (ipt *IPTable) Refresh() error {
 	ipt.log.Warning("proxy.iptable.refresh:%+v", ipt.conf.IPS)
 	ipt.mu.Lock()
 	defer ipt.mu.Unlock()
 
-	ipt.iptable = make(map[string]*IP)
+	ipt.iptable = make(map[string]interface{})
 	if ipt.conf.IPS != nil {
 		for _, ip := range ipt.conf.IPS {
-			IP := &IP{ip: ip}
-			ipt.iptable[ip] = IP
+			if err := addToIPTable(ipt, ip); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
-// Check used to check a whether the ip is in ip table or not.
+// Check used to check whether the ip is in ip table or not.
 func (ipt *IPTable) Check(address string) bool {
 	ipt.mu.Lock()
 	defer ipt.mu.Unlock()
 
-	if len(ipt.iptable) == 0 {
+	// if address is in iptable[address], just return
+	_, ok := ipt.iptable[address]
+	if ok {
 		return true
 	}
-	if _, ok := ipt.iptable[address]; !ok {
-		return false
+	// check if address is match with ip regexp
+	for _, ip := range ipt.iptable {
+		switch ip.(type) {
+		case *regexp.Regexp:
+			if ip.(*regexp.Regexp).MatchString(address) {
+				return true
+			}
+		}
 	}
-	return true
+	return false
 }

--- a/src/proxy/iptable_test.go
+++ b/src/proxy/iptable_test.go
@@ -37,7 +37,8 @@ func TestProxyIptables(t *testing.T) {
 
 	// Add.
 	{
-		iptable.Add("127.0.0.1")
+		err := iptable.Add("127.0.0.1")
+		assert.Nil(t, err)
 	}
 
 	// OK.
@@ -49,7 +50,8 @@ func TestProxyIptables(t *testing.T) {
 	// Remove.
 	{
 		iptable.Remove("127.0.0.1")
-		iptable.Add("127.0.0.2")
+		err := iptable.Add("127.0.0.2")
+		assert.Nil(t, err)
 	}
 
 	// Check.
@@ -58,9 +60,70 @@ func TestProxyIptables(t *testing.T) {
 		assert.False(t, got)
 	}
 
+	// Add.
+	{
+		err := iptable.Add("*")
+		assert.Nil(t, err)
+	}
+
+	// Add err, err regexp format.
+	{
+		err := iptable.Add("172.10.[0-9")
+		assert.NotNil(t, err)
+	}
+
+	// Check.
+	{
+		got := iptable.Check("128.0.0.2")
+		assert.True(t, got)
+	}
+
+	// Remove.
+	{
+		iptable.Remove("127.0.0.2")
+		iptable.Remove("*")
+	}
+
+	// Add.
+	{
+		err := iptable.Add("172.16.[0-9]+.[0-9]+")
+		assert.Nil(t, err)
+	}
+
+	// Check.
+	{
+		got := iptable.Check("128.0.0.2")
+		assert.False(t, got)
+		got = iptable.Check("172.16.1.1")
+		assert.True(t, got)
+		got = iptable.Check("172.1.1.1")
+		assert.False(t, got)
+	}
+
 	// Refresh.
 	{
 		proxy.SetAllowIP([]string{"x", "y"})
-		iptable.Refresh()
+		err := iptable.Refresh()
+		assert.Nil(t, err)
+		proxy.SetAllowIP([]string{"192.168.0.1", "10.1.*"})
+		err = iptable.Refresh()
+		assert.Nil(t, err)
+	}
+
+	// Check.
+	{
+		got := iptable.Check("192.168.0.1")
+		assert.True(t, got)
+		got = iptable.Check("10.1.1.1")
+		assert.True(t, got)
+		got = iptable.Check("10.2.1.1")
+		assert.False(t, got)
+	}
+
+	// Refresh err, wrong regexp format
+	{
+		proxy.SetAllowIP([]string{"172.10.[0-9"})
+		err := iptable.Refresh()
+		assert.NotNil(t, err)
 	}
 }


### PR DESCRIPTION
[summary]
The config allowsip supports address segments regexp defined by users.
address supported may be like: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
ip regexp is "*", that means allows all ip connect to radon

[test case]
iptable_test.go
[patch codecov]
src/proxy/iptable.go 97.8%