### PR TITLE
*: fix the bug that columns are case sensitive #673

### DIFF
--- a/intergration/radon-test/r/ddl.result
+++ b/intergration/radon-test/r/ddl.result
@@ -22,6 +22,12 @@ show create table integrate_test.t;
 Table	Create Table
 t	CREATE TABLE `t` (\n  `a` int(11) NOT NULL,\n  `b` int(11) NOT NULL,\n  `c` char(10) DEFAULT NULL,\n  PRIMARY KEY (`a`,`b`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8\n/*!50100 PARTITION BY HASH(a) */
 
+alter table integrate_test.t drop column A;
+ERROR 1105 (HY000): unsupported: cannot.drop.the.column.on.shard.key
+
+alter table integrate_test.t modify column A bigint;
+ERROR 1105 (HY000): unsupported: cannot.modify.the.column.on.shard.key
+
 drop table integrate_test.t;
 
 

--- a/intergration/radon-test/r/select.result
+++ b/intergration/radon-test/r/select.result
@@ -10,10 +10,35 @@ a	c
 2	3
 0	1
 
+select a, b c from integrate_test.t where a in (0,1,2) order by C desc;
+a	c
+2	3
+0	1
+
+select a, b from integrate_test.t where A>0;
+a	b
+2	3
+
+select sum(a), b from integrate_test.t where a>=0 group by B;
+sum(a)	b
+0	1
+2	3
+
 select c from integrate_test.t;
 ERROR 1054 (42S22): Unknown column 'c' in 'field list'
 
+
+create table integrate_test.s(a int key, b int) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+insert into integrate_test.s(a, b) values(0,1), (2,2);
+
+select t.a, s.b from integrate_test.t join integrate_test.s on t.A=s.a where t.a>0;
+a	b
+2	2
+
 drop table integrate_test.t;
+
+drop table integrate_test.s;
 
 
 drop database integrate_test;

--- a/intergration/radon-test/t/ddl.test
+++ b/intergration/radon-test/t/ddl.test
@@ -12,6 +12,8 @@ create table integrate_test.t(
         c char(10),
         primary key(a, b)) ENGINE=InnoDB DEFAULT CHARSET=utf8 PARTITION BY HASH(a);
 show create table integrate_test.t;
+alter table integrate_test.t drop column A;
+alter table integrate_test.t modify column A bigint;
 drop table integrate_test.t;
 
 create table integrate_test.t(

--- a/intergration/radon-test/t/select.test
+++ b/intergration/radon-test/t/select.test
@@ -3,7 +3,15 @@ create database integrate_test DEFAULT CHARSET=utf8;
 create table integrate_test.t(a int key, b int) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 insert into integrate_test.t(a, b) values(0,1), (2,3);
 select a, b c from integrate_test.t where a in (0,1,2) order by a desc;
+select a, b c from integrate_test.t where a in (0,1,2) order by C desc;
+select a, b from integrate_test.t where A>0;
+select sum(a), b from integrate_test.t where a>=0 group by B;
 select c from integrate_test.t;
+
+create table integrate_test.s(a int key, b int) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+insert into integrate_test.s(a, b) values(0,1), (2,2);
+select t.a, s.b from integrate_test.t join integrate_test.s on t.A=s.a where t.a>0;
 drop table integrate_test.t;
+drop table integrate_test.s;
 
 drop database integrate_test;

--- a/src/planner/builder/aggregate_plan.go
+++ b/src/planner/builder/aggregate_plan.go
@@ -123,7 +123,7 @@ func (p *AggregatePlan) analyze() error {
 		// check: groupby field in select list
 		idx := -1
 		for _, null := range nullAggrs {
-			if null.Field == by.field {
+			if strings.EqualFold(null.Field, by.field) {
 				idx = null.Index
 				break
 			}

--- a/src/planner/builder/common.go
+++ b/src/planner/builder/common.go
@@ -9,6 +9,8 @@
 package builder
 
 import (
+	"strings"
+
 	"router"
 
 	"github.com/pkg/errors"
@@ -71,7 +73,7 @@ func checkShard(table, col string, tbInfos map[string]*tableInfo, router *router
 		return false, errors.Errorf("unsupported: unknown.column.'%s.%s'.in.field.list", table, col)
 	}
 
-	if tbInfo.shardKey != "" && tbInfo.shardKey == col {
+	if tbInfo.shardKey != "" && strings.EqualFold(tbInfo.shardKey, col) {
 		return true, nil
 	}
 	return false, nil

--- a/src/planner/builder/expr.go
+++ b/src/planner/builder/expr.go
@@ -169,7 +169,7 @@ func GetDMLRouting(database, table, shardkey string, where *sqlparser.Where, rou
 
 func nameMatch(node sqlparser.Expr, table, shardkey string) bool {
 	colname, ok := node.(*sqlparser.ColName)
-	return ok && (colname.Qualifier.Name.String() == "" || colname.Qualifier.Name.String() == table) && (colname.Name.String() == shardkey)
+	return ok && (colname.Qualifier.Name.String() == "" || colname.Qualifier.Name.String() == table) && (colname.Name.EqualString(shardkey))
 }
 
 // splitAndExpression breaks up the Expr into AND-separated conditions

--- a/src/planner/builder/expr_test.go
+++ b/src/planner/builder/expr_test.go
@@ -26,6 +26,7 @@ func TestGetDMLRouting(t *testing.T) {
 		"select * from B where B.id in (1,2,3)",
 		"select * from B where id = 1 or id =2 or id =3",
 		"select * from B where B.id in (1,2,c)",
+		"select * from B where ID = 10",
 	}
 
 	want := []int{
@@ -35,6 +36,7 @@ func TestGetDMLRouting(t *testing.T) {
 		1,
 		1,
 		2,
+		1,
 	}
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	database := "sbtest"

--- a/src/planner/builder/from.go
+++ b/src/planner/builder/from.go
@@ -277,12 +277,12 @@ func mergeRoutes(lmn, rmn *MergeNode, joinExpr *sqlparser.JoinTableExpr, otherJo
 // isSameShard used to judge lcn|rcn contain shardkey and have same shards.
 func isSameShard(ltb, rtb map[string]*tableInfo, lcn, rcn *sqlparser.ColName) bool {
 	lt := ltb[lcn.Qualifier.Name.String()]
-	if lt.shardKey == "" || lt.shardKey != lcn.Name.String() {
+	if lt.shardKey == "" || !lcn.Name.EqualString(lt.shardKey) {
 		return false
 	}
 	ltp := lt.tableConfig.Partitions
 	rt := rtb[rcn.Qualifier.Name.String()]
-	if rt.shardKey == "" || rt.shardKey != rcn.Name.String() {
+	if rt.shardKey == "" || !rcn.Name.EqualString(rt.shardKey) {
 		return false
 	}
 	rtp := rt.tableConfig.Partitions

--- a/src/planner/builder/join_node.go
+++ b/src/planner/builder/join_node.go
@@ -9,6 +9,8 @@
 package builder
 
 import (
+	"strings"
+
 	"router"
 	"xcontext"
 
@@ -609,7 +611,7 @@ func (j *JoinNode) pushOtherFilter(node PlanNode, tuple selectTuple) (int, error
 		fields := node.getFields()
 		for i, field := range fields {
 			if field.isCol {
-				if table == field.info.referTables[0] && tuple.field == field.field {
+				if table == field.info.referTables[0] && strings.EqualFold(tuple.field, field.field) {
 					index = i
 					break
 				}
@@ -720,7 +722,7 @@ func (j *JoinNode) buildOrderBy(node PlanNode, tuple selectTuple) JoinKey {
 		fields := node.getFields()
 		for i, field := range fields {
 			if field.isCol {
-				if table == field.info.referTables[0] && tuple.field == field.field {
+				if table == field.info.referTables[0] && strings.EqualFold(tuple.field, field.field) {
 					index = i
 					break
 				}
@@ -866,7 +868,7 @@ func (j *JoinNode) procure(col *sqlparser.ColName) string {
 	index := -1
 	for i, tuple := range tuples {
 		if tuple.isCol {
-			if field == tuple.field && table == tuple.info.referTables[0] {
+			if strings.EqualFold(field, tuple.field) && table == tuple.info.referTables[0] {
 				index = i
 				break
 			}

--- a/src/planner/builder/merge_node.go
+++ b/src/planner/builder/merge_node.go
@@ -11,6 +11,7 @@ package builder
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"router"
@@ -109,7 +110,7 @@ func (m *MergeNode) pushKeyFilter(filter exprInfo, table, field string) error {
 	m.addWhere(expr)
 
 	tbInfo := m.referTables[table]
-	if field == tbInfo.shardKey && len(filter.vals) > 0 {
+	if strings.EqualFold(tbInfo.shardKey, field) && len(filter.vals) > 0 {
 		for _, val := range filter.vals {
 			if err := fetchIndex(tbInfo, val, m.router); err != nil {
 				return err

--- a/src/planner/builder/orderby_plan_test.go
+++ b/src/planner/builder/orderby_plan_test.go
@@ -30,6 +30,7 @@ func TestOrderByPlan(t *testing.T) {
 		"select a from A order by A.a",
 		"select A.a from A order by a",
 		"select a as b from A order by a",
+		"select a as b from A order by B",
 		"select a as b from A order by A.a",
 		"select a,b from A order by c",
 	}

--- a/src/planner/builder/project.go
+++ b/src/planner/builder/project.go
@@ -10,6 +10,7 @@ package builder
 
 import (
 	"fmt"
+	"strings"
 
 	"router"
 
@@ -289,7 +290,7 @@ func getSelectExprs(node sqlparser.SelectStatement) sqlparser.SelectExprs {
 
 func checkInTuple(field, table string, tuples []selectTuple) (bool, *selectTuple) {
 	for _, tuple := range tuples {
-		if table == "" && (tuple.field == "*" || field == tuple.alias) {
+		if table == "" && (tuple.field == "*" || strings.EqualFold(field, tuple.alias)) {
 			return true, &tuple
 		}
 
@@ -298,7 +299,7 @@ func checkInTuple(field, table string, tuples []selectTuple) (bool, *selectTuple
 		}
 
 		if tuple.isCol {
-			if field == tuple.field && (table == "" || table == tuple.info.referTables[0]) {
+			if strings.EqualFold(field, tuple.field) && (table == "" || table == tuple.info.referTables[0]) {
 				return true, &tuple
 			}
 		}
@@ -339,11 +340,11 @@ func checkGroupBy(exprs sqlparser.GroupBy, fields []selectTuple, router *router.
 
 		for _, tuple := range fields {
 			find := false
-			if table == "" && field == tuple.alias {
+			if table == "" && strings.EqualFold(field, tuple.alias) {
 				find = true
 			} else {
 				if tuple.isCol {
-					if field == tuple.field && (table == "" || table == tuple.info.referTables[0]) {
+					if strings.EqualFold(field, tuple.field) && (table == "" || table == tuple.info.referTables[0]) {
 						find = true
 					}
 				}

--- a/src/planner/builder/project_test.go
+++ b/src/planner/builder/project_test.go
@@ -73,6 +73,7 @@ func TestCheckGroupBy(t *testing.T) {
 		"select A.id as a from A group by a",
 		"select A.id+G.id as id from A,G group by id",
 		"select A.id from A group by id",
+		"select A.id as tmp from A group by TMP",
 		"select id as a from A group by id",
 		"select id as a from A group by A.id",
 	}
@@ -82,6 +83,7 @@ func TestCheckGroupBy(t *testing.T) {
 		0,
 		0,
 		1,
+		0,
 		0,
 		0,
 		0,

--- a/src/planner/common.go
+++ b/src/planner/common.go
@@ -31,7 +31,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 func isUpdateShardKey(exprs sqlparser.UpdateExprs, shardkey string) bool {
 	if shardkey != "" {
 		for _, assignment := range exprs {
-			if shardkey == assignment.Name.Name.String() {
+			if assignment.Name.Name.EqualString(shardkey) {
 				return true
 			}
 		}

--- a/src/planner/ddl_plan.go
+++ b/src/planner/ddl_plan.go
@@ -77,11 +77,11 @@ func (p *DDLPlan) checkUnsupportedOperations(database, table string) error {
 	if shardKey != "" {
 		switch node.Action {
 		case sqlparser.AlterDropColumnStr:
-			if shardKey == node.DropColumnName {
+			if strings.EqualFold(shardKey, node.DropColumnName) {
 				return errors.New("unsupported: cannot.drop.the.column.on.shard.key")
 			}
 		case sqlparser.AlterModifyColumnStr:
-			if shardKey == node.ModifyColumnDef.Name.String() {
+			if node.ModifyColumnDef.Name.EqualString(shardKey) {
 				return errors.New("unsupported: cannot.modify.the.column.on.shard.key")
 			}
 			// constraint check in column definition

--- a/src/planner/ddl_plan_test.go
+++ b/src/planner/ddl_plan_test.go
@@ -149,6 +149,8 @@ func TestDROPPlan(t *testing.T) {
 func TestDDLAlterError(t *testing.T) {
 	results := []string{
 		"unsupported: cannot.modify.the.column.on.shard.key",
+		"unsupported: cannot.modify.the.column.on.shard.key",
+		"unsupported: cannot.drop.the.column.on.shard.key",
 		"unsupported: cannot.drop.the.column.on.shard.key",
 		"The unique/primary constraint should be only defined on the sharding key column[id]",
 		"The unique/primary constraint should be only defined on the sharding key column[id]",
@@ -166,7 +168,9 @@ func TestDDLAlterError(t *testing.T) {
 	// "alter table A add column(c14 int, c15 varchar(100), unique(c12))",
 	querys := []string{
 		"alter table A modify column id int",
+		"alter table A modify column ID int",
 		"alter table A drop column id",
+		"alter table A drop column ID",
 		"alter table A modify column b varchar(1) key",
 		"alter table A modify column b varchar(1) primary key",
 		"alter table A modify column b varchar(1) unique",

--- a/src/planner/insert_plan.go
+++ b/src/planner/insert_plan.go
@@ -116,7 +116,7 @@ func (p *InsertPlan) Build() error {
 	// Find the shard key index.
 	idx := -1
 	for i, column := range node.Columns {
-		if column.String() == shardKey {
+		if column.EqualString(shardKey) {
 			idx = i
 			break
 		}
@@ -165,7 +165,7 @@ func (p *InsertPlan) Build() error {
 
 	// sorts SQL by rewrittenTable in increasing order to avoid deadlock #605.
 	ks := []string{}
-	for k, _ := range vals {
+	for k := range vals {
 		ks = append(ks, k)
 	}
 	sort.Strings(ks)

--- a/src/planner/insert_plan_test.go
+++ b/src/planner/insert_plan_test.go
@@ -62,11 +62,27 @@ func TestInsertPlan(t *testing.T) {
 		}
 	]
 }`,
+		`{
+	"RawQuery": "insert into sbtest.A(ID, B, C) values(1,2,3),(23,4,5), (65536,3,4)",
+	"Partitions": [
+		{
+			"Query": "insert into sbtest.A5(ID, B, C) values (65536, 3, 4)",
+			"Backend": "backend5",
+			"Range": "[256-512)"
+		},
+		{
+			"Query": "insert into sbtest.A6(ID, B, C) values (1, 2, 3), (23, 4, 5)",
+			"Backend": "backend6",
+			"Range": "[512-4096)"
+		}
+	]
+}`,
 	}
 	querys := []string{
 		"insert into A(id, b, c) values(1,2,3) on duplicate key update c=11",
 		"insert into A(id, b, c) values(1,2,3),(23,4,5), (65536,3,4)",
 		"insert into sbtest.A(id, b, c) values(1,2,3),(23,4,5), (65536,3,4)",
+		"insert into sbtest.A(ID, B, C) values(1,2,3),(23,4,5), (65536,3,4)",
 	}
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))

--- a/src/proxy/ddl_test.go
+++ b/src/proxy/ddl_test.go
@@ -675,7 +675,7 @@ func TestProxyDDLColumn(t *testing.T) {
 		"alter table t2 add column(status int, bool int, datetime datetime, enum char)",
 	}
 	queryerr := []string{
-		"alter table t1 drop column id",
+		"alter table t1 drop column ID",
 		"alter table t1 modify column id bigint",
 	}
 	wants := []string{
@@ -780,6 +780,7 @@ func TestProxyDDLCreateTable(t *testing.T) {
 		"create table t8(a int, b int) partition by hash(a)",
 		"create table t9(a int, b timestamp(5) on update current_timestamp(5) column_format fixed column_format default column_format dynamic) partition by hash(a)",
 		"create table t10(a int column_format fixed column_format default column_format dynamic) comment='comment option' engine=tokudb default charset='utf8' avg_row_length=123 checksum=1 collate='utf8_bin' compression='lz4' connection='id' data directory='/data' index directory='/index' delay_key_write=1 encryption='n' insert_method=First key_block_size=1 max_rows=3 min_rows=2 pack_keys=default password='pwd' row_format=dynamic stats_auto_recalc=1 stats_persistent=default stats_sample_pages=65535 tablespace=storage partition by hash(a)",
+		"create table t11(a int, b int) partition by hash(A)",
 	}
 
 	for _, query := range querys {
@@ -966,10 +967,12 @@ func TestProxyDDLConstraintError(t *testing.T) {
 		"create table t25(a int unique, b int key, index `name` (a))engine=tokudb default charset=utf8  PARTITION  BY hash(a)  ",
 		"create table t26(a int unique, b int key, unique index `name` (a))engine=tokudb default charset=utf8  PARTITION  BY hash(a)  ",
 		"create table t27(a int unique, b int key, unique key `name` (a))engine=tokudb default charset=utf8  PARTITION  BY hash(a)  ",
+		"create table t28(a int primary key, b int unique)",
 	}
 
 	results := []string{
 		"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use, syntax error at position 35 near 'index' (errno 1149) (sqlstate 42000)",
+		"The unique/primary constraint should be only defined on the sharding key column[a] (errno 1105) (sqlstate HY000)",
 		"The unique/primary constraint should be only defined on the sharding key column[a] (errno 1105) (sqlstate HY000)",
 		"The unique/primary constraint should be only defined on the sharding key column[a] (errno 1105) (sqlstate HY000)",
 		"The unique/primary constraint should be only defined on the sharding key column[a] (errno 1105) (sqlstate HY000)",


### PR DESCRIPTION
[summary]
Set the column and column aliases not case-sensitive.

[test case]
src/planner/builder/expr_test.go
src/planner/builder/from_test.go
src/planner/builder/orderby_plan_test.go
src/planner/builder/project_test.go
src/planner/ddl_plan_test.go
src/planner/insert_plan_test.go
src/proxy/ddl_test.go

[patch codecov]
src/planner/builder/common.go 100%
src/planner/builder/expr.go 99.0%
src/planner/builder/from.go 99.3%
src/planner/builder/merge_node.go 97.3%
src/planner/builder/project.go 98.2%
src/planner/common.go 100%
src/planner/ddl_plan.go 93.8%
src/planner/insert_plan.go 96.0%
src/proxy/ddl.go 94.7%