### PR TITLE
*: fix the backendnum statistics error #698

### DIFF
--- a/src/backend/scatter.go
+++ b/src/backend/scatter.go
@@ -174,6 +174,7 @@ func (scatter *Scatter) LoadConfig() error {
 		log.Error("scatter.parse.json.file[%v].error:%v", file, err)
 		return err
 	}
+	monitor.BackendSet("backend", 0)
 	for _, backend := range conf.Backends {
 		if err := scatter.add(backend); err != nil {
 			log.Error("scatter.add.backend[%+v].error:%v", backend.Name, err)

--- a/src/monitor/monitor.go
+++ b/src/monitor/monitor.go
@@ -128,6 +128,11 @@ func QueryTotalCounterInc(command string, result string) {
 	queryTotalCounter.WithLabelValues(command, result).Inc()
 }
 
+// BackendSet set backend num.
+func BackendSet(btype string, v float64) {
+	backendNum.WithLabelValues(btype).Set(v)
+}
+
 // BackendInc add 1
 func BackendInc(btype string) {
 	backendNum.WithLabelValues(btype).Inc()

--- a/src/monitor/monitor_test.go
+++ b/src/monitor/monitor_test.go
@@ -97,25 +97,21 @@ func TestBackendIncDec(t *testing.T) {
 	}
 
 	backend := "backend"
-	backup := "backup"
-
 	BackendInc(backend)
-	BackendInc(backup)
-
 	v1 := getBackendNum(backend)
-	v2 := getBackendNum(backup)
-
 	assert.EqualValues(t, 1, v1)
-	assert.EqualValues(t, 1, v2)
+
+	BackendSet(backend, 2)
+	v1 = getBackendNum(backend)
+	assert.EqualValues(t, 2, v1)
 
 	BackendDec(backend)
-	BackendDec(backup)
-
 	v1 = getBackendNum(backend)
-	v2 = getBackendNum(backup)
+	assert.EqualValues(t, 1, v1)
 
+	BackendSet(backend, 0)
+	v1 = getBackendNum(backend)
 	assert.EqualValues(t, 0, v1)
-	assert.EqualValues(t, 0, v2)
 }
 
 func TestDiskUsageSet(t *testing.T) {


### PR DESCRIPTION
[summary]
The slave node of Radon will synchronize metadata from the master node. At this time, backend.json will be reloaded, causing backendnum to be counted repeatedly.

Set 0 before reload the backend config.

[test case]
src/monitor/monitor_test.go

[patch codecov]
src/monitor/monitor.go 96.3%
src/backend/scatter.go 88.7%