### PR TITLE
*: fix bug explain has problem of escaping characters #706

### DIFF
--- a/src/planner/builder/aggregate_plan.go
+++ b/src/planner/builder/aggregate_plan.go
@@ -9,12 +9,12 @@
 package builder
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/common"
 	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
 	"github.com/xelabs/go-mysqlstack/xlog"
 )
@@ -160,11 +160,11 @@ func (p *AggregatePlan) JSON() string {
 	buf.Myprintf("%v", p.rewritten)
 	a.ReWritten = buf.String()
 
-	bout, err := json.MarshalIndent(a, "", "\t")
+	out, err := common.ToJSONString(a, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return string(bout)
+	return out
 }
 
 // NormalAggregators returns the aggregators.

--- a/src/planner/builder/limit_plan.go
+++ b/src/planner/builder/limit_plan.go
@@ -9,7 +9,6 @@
 package builder
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -110,11 +109,11 @@ func (p *LimitPlan) Type() ChildType {
 
 // JSON returns the plan info.
 func (p *LimitPlan) JSON() string {
-	bout, err := json.MarshalIndent(p, "", "\t")
+	out, err := common.ToJSONString(p, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return string(bout)
+	return out
 }
 
 // ReWritten used to re-write the limit clause.

--- a/src/planner/builder/orderby_plan.go
+++ b/src/planner/builder/orderby_plan.go
@@ -9,10 +9,9 @@
 package builder
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 	"github.com/xelabs/go-mysqlstack/sqlparser"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/common"
 	"github.com/xelabs/go-mysqlstack/xlog"
 )
 
@@ -138,9 +137,9 @@ func (p *OrderByPlan) Type() ChildType {
 
 // JSON returns the plan info.
 func (p *OrderByPlan) JSON() string {
-	bout, err := json.MarshalIndent(p, "", "\t")
+	out, err := common.ToJSONString(p, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return string(bout)
+	return out
 }

--- a/src/planner/ddl_plan.go
+++ b/src/planner/ddl_plan.go
@@ -9,7 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -291,13 +290,12 @@ func (p *DDLPlan) JSON() string {
 		RawQuery:   p.RawQuery,
 		Partitions: parts,
 	}
-	// If exp include escape, json will add '\' before it.
-	// e.g.: "\n\t tbl \n" will be "\\n\\t tbl \\n"
-	bout, err := json.MarshalIndent(exp, "", "\t")
+
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/delete_plan.go
+++ b/src/planner/delete_plan.go
@@ -9,8 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
-
 	"planner/builder"
 	"router"
 	"xcontext"
@@ -136,11 +134,11 @@ func (p *DeletePlan) JSON() string {
 		RawQuery:   p.RawQuery,
 		Partitions: parts,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/insert_plan.go
+++ b/src/planner/insert_plan.go
@@ -9,7 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
 	"sort"
 
 	"router"
@@ -203,11 +202,11 @@ func (p *InsertPlan) JSON() string {
 		RawQuery:   p.RawQuery,
 		Partitions: parts,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/others_plan.go
+++ b/src/planner/others_plan.go
@@ -9,7 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
 	"sort"
 
 	"router"
@@ -127,11 +126,11 @@ func (p *OthersPlan) JSON() string {
 		RawQuery:   p.RawQuery,
 		Partitions: parts,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/select_plan.go
+++ b/src/planner/select_plan.go
@@ -9,7 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
 	"errors"
 	"strings"
 
@@ -161,11 +160,11 @@ func (p *SelectPlan) JSON() string {
 		HashGroupBy: hashGroup,
 		Limit:       lim,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/select_plan_test.go
+++ b/src/planner/select_plan_test.go
@@ -21,36 +21,36 @@ import (
 func TestSelectPlan(t *testing.T) {
 	results := []string{
 		`{
-	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.A where id\u003e1 group by a,b order by A.a desc limit 10 offset 100",
+	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.A where id>1 group by a,b order by A.a desc limit 10 offset 100",
 	"Project": "1, sum(a), avg(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A1 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A1 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend1",
 			"Range": "[0-32)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A2 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A2 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend2",
 			"Range": "[32-64)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A3 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A3 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend3",
 			"Range": "[64-96)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A4 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A4 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend4",
 			"Range": "[96-256)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A5 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A5 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend5",
 			"Range": "[256-512)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A6 as A where id \u003e 1 group by a, b order by A.a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from sbtest.A6 as A where id > 1 group by a, b order by A.a desc",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}
@@ -74,36 +74,36 @@ func TestSelectPlan(t *testing.T) {
 	}
 }`,
 		`{
-	"RawQuery": "select id, sum(a) as A from A group by id having id\u003e1000",
+	"RawQuery": "select id, sum(a) as A from A group by id having id>1000",
 	"Project": "id, A",
 	"Partitions": [
 		{
-			"Query": "select id, sum(a) as A from sbtest.A1 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A1 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend1",
 			"Range": "[0-32)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A2 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A2 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend2",
 			"Range": "[32-64)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A3 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A3 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend3",
 			"Range": "[64-96)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A4 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A4 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend4",
 			"Range": "[96-256)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A5 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A5 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend5",
 			"Range": "[256-512)"
 		},
 		{
-			"Query": "select id, sum(a) as A from sbtest.A6 as A group by id having id \u003e 1000 order by id asc",
+			"Query": "select id, sum(a) as A from sbtest.A6 as A group by id having id > 1000 order by id asc",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}
@@ -113,11 +113,11 @@ func TestSelectPlan(t *testing.T) {
 	]
 }`,
 		`{
-	"RawQuery": "select id,a from sbtest.A where (a\u003e1 and (id=1))",
+	"RawQuery": "select id,a from sbtest.A where (a>1 and (id=1))",
 	"Project": "id, a",
 	"Partitions": [
 		{
-			"Query": "select id, a from sbtest.A6 as A where a \u003e 1 and id = 1",
+			"Query": "select id, a from sbtest.A6 as A where a > 1 and id = 1",
 			"Backend": "backend6",
 			"Range": "[512-4096)"
 		}
@@ -303,22 +303,22 @@ func TestSelectPlan(t *testing.T) {
 	]
 }`,
 		`{
-	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.S where id\u003e1 group by a,b order by a desc limit 10 offset 100",
+	"RawQuery": "select 1, sum(a),avg(a),a,b from sbtest.S where id>1 group by a,b order by a desc limit 10 offset 100",
 	"Project": "1, sum(a), avg(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), avg(a), a, b from sbtest.S where id \u003e 1 group by a, b order by a desc limit 100, 10",
+			"Query": "select 1, sum(a), avg(a), a, b from sbtest.S where id > 1 group by a, b order by a desc limit 100, 10",
 			"Backend": "backend1",
 			"Range": ""
 		}
 	]
 }`,
 		`{
-	"RawQuery": "select sum(G.a), S.b from G join S on G.id=S.id where G.id\u003e1 group by S.b",
+	"RawQuery": "select sum(G.a), S.b from G join S on G.id=S.id where G.id>1 group by S.b",
 	"Project": "sum(G.a), b",
 	"Partitions": [
 		{
-			"Query": "select sum(G.a), S.b from sbtest.G join sbtest.S on G.id = S.id where G.id \u003e 1 group by S.b",
+			"Query": "select sum(G.a), S.b from sbtest.G join sbtest.S on G.id = S.id where G.id > 1 group by S.b",
 			"Backend": "backend1",
 			"Range": ""
 		}

--- a/src/planner/union_plan.go
+++ b/src/planner/union_plan.go
@@ -9,8 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
-
 	"planner/builder"
 	"router"
 	"xcontext"
@@ -115,11 +113,11 @@ func (p *UnionPlan) JSON() string {
 		GatherMerge: gatherMerge,
 		Limit:       lim,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/planner/update_plan.go
+++ b/src/planner/update_plan.go
@@ -9,8 +9,6 @@
 package planner
 
 import (
-	"encoding/json"
-
 	"planner/builder"
 	"router"
 	"xcontext"
@@ -141,11 +139,11 @@ func (p *UpdatePlan) JSON() string {
 		RawQuery:   p.RawQuery,
 		Partitions: parts,
 	}
-	bout, err := json.MarshalIndent(exp, "", "\t")
+	out, err := common.ToJSONString(exp, false, "", "\t")
 	if err != nil {
 		return err.Error()
 	}
-	return common.BytesToString(bout)
+	return out
 }
 
 // Size returns the memory size.

--- a/src/proxy/explain_test.go
+++ b/src/proxy/explain_test.go
@@ -56,156 +56,156 @@ func TestProxyExplain(t *testing.T) {
 		qr, err := client.FetchAll(query, -1)
 		assert.Nil(t, err)
 		want := `{
-	"RawQuery": " select 1, sum(a),avg(a),a,b from test.t1 as t1 where id\u003e1 group by a,b order by a desc limit 10 offset 100",
+	"RawQuery": " select 1, sum(a),avg(a),a,b from test.t1 as t1 where id>1 group by a,b order by a desc limit 10 offset 100",
 	"Project": "1, sum(a), avg(a), a, b",
 	"Partitions": [
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0000 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0000 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[0-128)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0001 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0001 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[128-256)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0002 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0002 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[256-384)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0003 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0003 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[384-512)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0004 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0004 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[512-640)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0005 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0005 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend0",
 			"Range": "[640-819)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0006 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0006 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[819-947)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0007 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0007 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[947-1075)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0008 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0008 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[1075-1203)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0009 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0009 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[1203-1331)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0010 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0010 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[1331-1459)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0011 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0011 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend1",
 			"Range": "[1459-1638)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0012 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0012 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[1638-1766)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0013 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0013 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[1766-1894)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0014 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0014 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[1894-2022)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0015 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0015 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[2022-2150)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0016 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0016 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[2150-2278)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0017 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0017 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend2",
 			"Range": "[2278-2457)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0018 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0018 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[2457-2585)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0019 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0019 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[2585-2713)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0020 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0020 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[2713-2841)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0021 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0021 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[2841-2969)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0022 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0022 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[2969-3097)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0023 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0023 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend3",
 			"Range": "[3097-3276)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0024 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0024 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3276-3404)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0025 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0025 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3404-3532)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0026 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0026 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3532-3660)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0027 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0027 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3660-3788)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0028 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0028 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3788-3916)"
 		},
 		{
-			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0029 as t1 where id \u003e 1 group by a, b order by a desc",
+			"Query": "select 1, sum(a), sum(a) as ` + "`avg(a)`" + `, count(a), a, b from test.t1_0029 as t1 where id > 1 group by a, b order by a desc",
 			"Backend": "backend4",
 			"Range": "[3916-4096)"
 		}

--- a/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe.go
@@ -10,6 +10,8 @@
 package common
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"unsafe"
 )
@@ -36,4 +38,18 @@ func StringToBytes(s string) []byte {
 	bh := reflect.SliceHeader{Data: sh.Data, Len: sh.Len, Cap: sh.Len}
 
 	return *(*[]byte)(unsafe.Pointer(&bh))
+}
+
+// ToJSONString format v to the JSON encoding, return a string.
+func ToJSONString(v interface{}, escapeHTML bool, prefix, indent string) (string, error) {
+	bf := bytes.NewBuffer([]byte{})
+	jsonEncoder := json.NewEncoder(bf)
+	jsonEncoder.SetEscapeHTML(escapeHTML)
+	jsonEncoder.SetIndent(prefix, indent)
+	if err := jsonEncoder.Encode(v); err != nil {
+		return "", err
+	}
+	// Remove the newline added by (*Encoder).Encode.
+	bf.Truncate(bf.Len() - 1)
+	return bf.String(), nil
 }

--- a/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe_test.go
+++ b/src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe_test.go
@@ -10,8 +10,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBytesToString(t *testing.T) {
@@ -49,5 +50,28 @@ func TestStingToBytes(t *testing.T) {
 		want := []byte{0x53, 0x45, 0x4c, 0x45, 0x43, 0x54, 0x20, 0x2a, 0x20, 0x46, 0x52, 0x4f, 0x4d, 0x20, 0x74, 0x32}
 		got := StringToBytes("SELECT * FROM t2")
 		assert.Equal(t, want, got)
+	}
+}
+
+func TestToJSONString(t *testing.T) {
+	type input struct {
+		A string
+		B int
+	}
+
+	testcases := []struct {
+		in  *input
+		out string
+	}{
+		{
+			in:  &input{A: "a>1", B: 1},
+			out: "{\n\t\"A\": \"a>1\",\n\t\"B\": 1\n}",
+		},
+	}
+
+	for _, testcase := range testcases {
+		got, err := ToJSONString(testcase.in, false, "", "\t")
+		assert.Nil(t, err)
+		assert.Equal(t, testcase.out, got)
 	}
 }


### PR DESCRIPTION
[summary]
Use an Encoder by calling SetEscapeHTML(false) to avoid the mistake.

[test case]
src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe_test.go

[patch codecov]
src/vendor/github.com/xelabs/go-mysqlstack/sqlparser/depends/common/unsafe.go 94.4%